### PR TITLE
Update docs: tutorial and quickstart improvements for Audulus users

### DIFF
--- a/docs/lyte-dsp-quickstart.md
+++ b/docs/lyte-dsp-quickstart.md
@@ -1,13 +1,12 @@
-# Lyte DSP Quick Start — Building Audio DSP in Lyte
+# Lyte DSP Quick Start
 
-*A practical guide to common DSP building blocks in Audulus Lyte. The examples are meant to be
-small, pasteable, and easy to adapt.*
+*A practical starting guide for building audio tools in Audulus Lyte. The examples are small, easy to paste in, and meant to be changed.*
 
 ---
 
 ## The DSP Node
 
-When a new Lyte DSP node is created in Audulus, it shows this template:
+When you create a new Lyte DSP node in Audulus, it starts with this template:
 
 ```lyte
 // Inputs, outputs, `frames`, `sampleRate`, and `storage` are globals.
@@ -23,48 +22,46 @@ process {
 }
 ```
 
-That template is the whole interface. Everything below builds from it.
+That is the basic shape of a Lyte DSP node. Everything below builds on that pattern.
 
 ## Terms for New Users
 
-These words show up right away in the fresh-node comments:
+These are the main words you will see right away:
 
-- `input`, `output`: audio buffers for the current block. `input[i]` means “sample `i`.”
-- `frames`: how many samples are in the current block.
-- `sampleRate`: how many samples happen per second, usually `44100.0` or `48000.0`.
-- `storage`: extra sample memory for things like delay lines.
-- `globals`: variables declared outside `process`. They remember values between blocks.
-- `slice`: a buffer you index with `[...]`.
-- `MAX_FRAMES`: the largest block size Audulus may give the node. Use it for temporary arrays when needed.
+- `input`, `output`: the audio coming in and going out for the current block. `input[i]` means “sample number `i`”
+- `frames`: how many samples are in this block
+- `sampleRate`: how many samples happen each second, usually `44100.0` or `48000.0`
+- `storage`: extra memory for things like delay lines
+- `globals`: variables declared outside `process`. They keep their value from one block to the next
+- `slice`: a buffer you read with `[...]`
+- `MAX_FRAMES`: the biggest block size Audulus may send to the node. Use it when you need a temporary array
 
-You do not declare `input`, `output`, `frames`, `sampleRate`, or `storage` yourself.
-Audulus provides them.
+You do not create `frames`, `sampleRate`, or `storage` yourself. Audulus gives them to the node automatically.
 
 | Global | Type | Description |
 |---|---|---|
-| `input`, `output` | `[f32]` | Default port slices. Additional named ports are added in the Inspector. |
+| `input`, `output` | `[f32]` | Default port slices. Add ports as needed above the code viewer in the Inspector. |
 | `frames` | `i32` | Number of samples in this processing block. |
 | `sampleRate` | `f32` | Current sample rate, e.g. `44100.0`. |
-| `storage` | `[f32]` | Pre-allocated buffer for delay lines etc., sized in the Inspector. |
+| `storage` | `[f32]` | Pre-allocated buffer for delay lines etc., set the size in the Inspector. |
 | `MAX_FRAMES` | `i32` | Maximum possible block size — use to declare stack arrays. |
 
-**`init {}`** runs once when the node loads. Use it for setup.
+**`init {}`** runs once when the node loads. Use it for setup values.
 
-**`process { ... }`** runs once per block. Loop over `for i in 0 .. frames` and read or
-write the buffers.
+**`process { ... }`** runs once per block. Most audio work happens here inside `for i in 0 .. frames`.
 
 **Global `var`** is for state that should survive between blocks. Globals start at zero.
 
-**Indexing is zero-based.** In `for i in 0 .. frames`, valid indices are `0` through
-`frames - 1`. Use `freq[i]` for normal per-sample processing. Use `freq[0]` only when you
-intentionally want the first sample in the block.
+**Indexing starts at zero.** In `for i in 0 .. frames`, valid indices are `0` through
+`frames - 1`. Use `freq[i]` for normal sample-by-sample processing. Use `freq[0]` only when you
+intentionally want one control value for the whole block. If you are coming from Lua, this is different because Lua starts at `1`.
 
 ---
 
-## A Note on `sampleRate`
+## Using `sampleRate`
 
-`sampleRate` now behaves like a normal float. The usual pattern is to compute
-`1.0 / sampleRate` once in `init` and multiply by that inside `process`.
+`sampleRate` is a float. A common pattern is to compute `1.0 / sampleRate` once in
+`init` and then multiply by that inside `process`.
 
 ```lyte
 var inv_sr: f32
@@ -74,13 +71,13 @@ init {
 }
 ```
 
-This also avoids doing a division every sample.
+This also avoids doing a division on every sample.
 
 ---
 
 ## Do's and Don'ts
 
-These habits gave the most reliable results in the current Audulus build.
+These are good default habits for writing Lyte in Audulus.
 
 **Do:**
 - Prefer `f32` almost everywhere in DSP code.
@@ -90,13 +87,60 @@ These habits gave the most reliable results in the current Audulus build.
 - Read a port sample into a scratch `f32` first if the compiler gets ambiguous about expressions like `input[i] * inv_sr`.
 - Keep slice index proofs inline near `storage[...]` accesses when the safety checker complains.
 - Use `freq[i]`, `cutoff[i]`, and similar forms for normal per-sample processing. Use `freq[0]` only when you intentionally want one control value for the whole block.
+- Move expensive math out of the sample loop when true audio-rate updates are not needed.
+- Try block-rate control first when it sounds good enough. It is usually simpler and cheaper.
 
 **Don't:**
-- Don't assume Expr-node conveniences exist in Lyte. For example, `pi` is not built in here.
-- Don't use `sinf`, `cosf`, or other suffixed math names in Audulus Lyte.
+- Don't assume every Expr-node feature maps over exactly. Lyte does have built-in trig/math functions and stdlib helpers like `clamp(x, lo, hi)` and `mix(a, b, t)`, but constants like `pi` are still not built in.
+- Don't use `sinf`, `cosf`, or other suffixed math names in Audulus Lyte. Use unsuffixed names like `sin`, `cos`, `tan`, `atan2`, `sqrt`, `clamp`, and `mix`.
 - Don't rely on helper functions to prove slice indices are safe; the checker usually wants the bounds checks inline.
 - Don't use `assume` in node code — it is only allowed in the standard library or prelude.
 - Don't assume examples from the standalone Lyte repo will drop into Audulus unchanged.
+- Don't rely on block-form inline `if` expressions in assignments such as `let x = if ...` or `output[i] = if ...`. In Lyte those can trigger confusing parser errors. Use a normal assignment first, then a plain `if` block.
+
+---
+
+## Debug Printing
+
+`println` is useful for simple debugging. For numbers, write into a
+small text buffer first with `itoa` or `ftoa`, then print the buffer.
+
+### Hello World
+
+```lyte
+init {
+    println("hello world")
+}
+
+process {
+    for i in 0 .. frames {
+        output[i] = input[i]
+    }
+}
+```
+
+### Block Counter
+
+This prints how many times `process` has run so far.
+
+```lyte
+var calls: i32
+
+init {}
+
+process {
+    var buf: [i8; 32]
+    itoa(buf, calls)
+    println(buf)
+    calls = calls + 1
+
+    for i in 0 .. frames {
+        output[i] = input[i]
+    }
+}
+```
+
+Use debug printing sparingly. Printing every block gets noisy fast.
 
 ---
 
@@ -141,8 +185,7 @@ process {
 }
 ```
 
-`phase` remembers where the oscillator is in its cycle. `hz` is a scratch `f32` used to
-keep the compiler happy when doing math with `input[i]`.
+`phase` remembers where the oscillator is in its cycle. `hz` is just a temporary variable that makes the math clearer and avoids compiler confusion around `input[i]`.
 
 ---
 
@@ -169,7 +212,7 @@ process {
 }
 ```
 
-Use `let` for one-time values inside the loop. Use `var` for values that change.
+Use `let` for a value you set once and do not change. Use `var` for a value that changes.
 
 ---
 ## 1. Timer
@@ -242,8 +285,8 @@ process {
 `sync` is a rising-edge trigger. `hz * inv_sr` is the fraction of one cycle that passes
 per sample.
 
-> 🔄 *Audulus users: The built-in Audulus Phasor outputs `0` to `2π`. This one uses `0` to
-> `1`, which is often simpler in DSP code.*
+Note for Audulus users: the built-in Audulus Phasor outputs `0` to `2π`. This example uses `0` to
+`1`, which is often easier to work with in Lyte code.
 
 ### Clock
 
@@ -363,12 +406,15 @@ output[i] = phase * 2.0 - 1.0
 // triangle: fold the sawtooth
 output[i] = abs(phase * 2.0 - 1.0) * 2.0 - 1.0
 
-// square: if/else is an expression in Lyte
+// square
 var pw: f32   // global pulse width; 0.5 = 50% duty cycle
-output[i] = if phase < pw { 1.0 } else { -1.0 }
+output[i] = -1.0
+if phase < pw {
+    output[i] = 1.0
+}
 ```
 
-`if/else` can return a value directly, so there is no ternary operator to learn.
+This plain assignment style is a safe habit in Lyte and avoids parser trouble from inline `if` expressions.
 
 ---
 ## 4. Sample and Hold
@@ -526,7 +572,10 @@ process {
     for i in 0 .. frames {
         let x   = input[i]
         let fc  = cutoff[i]
-        let res = if q[i] < 0.001 { 0.001 } else { q[i] }
+        var res = q[i]
+        if res < 0.001 {
+            res = 0.001
+        }
         let w0    = 2.0 * 3.14159265 * fc * inv_sr
         let alpha = sin(w0) / (2.0 * res)
         let cs    = cos(w0)
@@ -549,7 +598,7 @@ process {
 ```
 
 This is direct form I using plain `f32` globals for the saved state. This flatter version
-is the one verified to behave correctly in the current Audulus build.
+is the one used in this guide.
 
 ### DC Blocker
 
@@ -619,10 +668,9 @@ process {
         }
 
         let read_pos_0 = write as f32 - delay
-        let read_pos = if read_pos_0 < 0.0 {
-            read_pos_0 + len as f32
-        } else {
-            read_pos_0
+        var read_pos = read_pos_0
+        if read_pos < 0.0 {
+            read_pos = read_pos + len as f32
         }
 
         let i0 = floor(read_pos) as i32

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,8 +1,6 @@
-# Learning Lyte — A Beginner's Guide
+# Learning Lyte
 
-*A walkthrough of the Lyte programming language for Audulus users familiar with Lua.*
-
-*Based on the official Lyte README, with notes for how Lyte currently behaves inside Audulus.*
+*A beginner-friendly guide to Lyte for Audulus users.*
 
 ---
 
@@ -33,22 +31,31 @@
 
 ## 1. What is Lyte?
 
-Lyte is a programming language designed specifically for writing Audulus nodes. Its job is the same as Lua in that context — take input signals, do math, produce output — but it approaches that job differently.
+Audulus has both a **Lyte DSP node** and a **DSP node**. The DSP node is for Lua scripting. The Lyte DSP node is for Lyte.
+
+Lyte is a language made for writing DSP code in Audulus. Like Lua in a DSP node, it takes input signals, does math, and produces output. The difference is mainly in how the language works and what it is best at.
+
+Both Lyte and Lua can essentially do the same core job in Audulus: take input signals, process frames of audio, and produce output. In practice, both use a similar `process` style where audio is handled sample by sample across a block of frames.
+
+They have different strengths:
+
+- **Lyte** is built for speed and optimized audio DSP.
+- **Lua** is a friendly, higher-level language with its own useful features, such as tables and string formatting.
 
 Lyte was designed with a few clear goals in mind:
 
-- **Familiar syntax** — it looks like a mix of two popular languages, Rust and Swift, but you don't need to know either of those to use it
-- **Fast** — it compiles directly to native machine code. An *interpreter* (like Lua uses) translates and executes your code on the fly as it runs. Lyte instead translates your entire program into instructions the CPU can run directly before it ever starts, which is generally much faster for math-heavy work like DSP.
-- **Safe** — it checks for common mistakes (like going out of bounds on an array) *before* your code runs, not during
-- **No memory management** — in many languages, the programmer has to manually request and release memory as they create and destroy data. Lyte avoids this entirely through its strict rules: because it doesn't allow certain kinds of complex data structures, it always knows exactly how much memory is needed upfront and never has to ask for more at runtime.
+- **Familiar syntax** — it looks a bit like other modern languages, but you do not need to know them first
+- **Fast** — Lyte turns your code into machine code ahead of time instead of interpreting it as it runs, which is helpful for heavy DSP math
+- **Safe** — it checks for common mistakes, like out-of-range array access, before the code runs
+- **Predictable** — it uses strict rules so the system knows what memory is needed up front
 
-Lyte is still new inside Audulus, and how it fits alongside Lua will become clearer as more people use it. As a rough starting point: Lyte may be well-suited for sample-rate DSP — filters, oscillators, waveshapers, anything that processes audio sample by sample at the highest speed. *(Lua may continue to be useful for control-rate work via `fill()`, for scripting that benefits from Lua's flexible tables, or anywhere Lua's looser rules are more convenient than Lyte's stricter ones — but this is a starting point for thinking, not a definitive guide.)*
+As a rough starting point, Lyte is a strong fit for sample-rate DSP: filters, oscillators, waveshapers, and other code that processes audio sample by sample at high speed. Lua is often a good fit when you want a more flexible scripting style.
 
 ---
 
 ## 2. Types — Static vs Dynamic Typing
 
-One of the most important conceptual shifts when coming from Lua is how Lyte handles types. It's worth spending a little extra time here, as it comes up in nearly everything else.
+One of the biggest differences from Lua is how Lyte handles types. This comes up everywhere, so it is worth getting comfortable with early.
 
 In Lua, variables have no fixed type — you can reassign a variable to a completely different kind of value at any time:
 
@@ -57,9 +64,9 @@ x = 42         -- a number
 x = "hello"    -- now x is text. totally fine in Lua!
 ```
 
-Lyte **won't allow that.** Once `x` holds a number, it always holds a number. This is called **static typing** — the *type* of every variable is locked in and checked before your code even runs.
+Lyte **won't allow that.** Once `x` is a number, it stays a number. This is called **static typing**. It means Lyte decides what kind of value each variable holds before the code runs.
 
-> 🔄 *Lua users: Lua is called "dynamically typed" — types are figured out as the program runs, so a variable can hold anything at any time. Lyte locks types in at compile time instead.*
+Note for Lua users: Lua lets one variable hold different kinds of values over time. Lyte does not.
 
 ### The basic types in Lyte
 
@@ -72,7 +79,7 @@ Lyte **won't allow that.** Once `x` holds a number, it always holds a number. Th
 | `i8` | A very small whole number, used for individual characters | `65` (the letter `A`) |
 | `u32` | A whole number that cannot be negative (unsigned) | `42`, `0` |
 
-Single characters can also be written with single quotes: `'a'`, `'Z'`, `'\n'` (newline). This is called a **character literal**.
+Single characters can also be written with single quotes: `'a'`, `'Z'`, `'\n'` (newline). This is called a character literal.
 
 Boolean values support the standard logical operators:
 
@@ -88,19 +95,19 @@ main {
 }
 ```
 
-**A note on `i32` vs `f32`:** The "32" refers to how many bits of memory the number uses — you don't need to worry about that detail. Just remember:
-- `i32` = whole numbers only (no decimal point)
-- `f32` = numbers with a decimal point
+**A note on `i32` vs `f32`:** The "32" is just part of the type name. You do not need to worry much about the low-level detail. The useful part is:
+- `i32` = 'i' is for integer, whole numbers only (no decimal point)
+- `f32` = 'f' is for float, numbers with a decimal point
 
-In audio and DSP work, you'll use `f32` constantly — audio signals, frequencies, and most math will be floating point values.
+In audio and DSP work, you will use `f32` constantly. Audio signals, frequencies, and most DSP math are floating-point values. This is especially true in Audulus, where normal input and output ports are `f32`.
 
-**A note on `f64`:** The language grammar also defines an `f64` type — a higher-precision decimal number. However, since Audulus currently works with 32-bit signal values throughout, `f64` may not be relevant or available in practice within Audulus nodes. It's listed here for completeness.
+**A note on `f64`:** The language grammar also defines an `f64` type, which is a higher-precision decimal number. In Audulus DSP work, `f32` is the type you'll usually use.
 
 ### Why does static typing matter?
 
-In audio DSP, you're doing thousands of math operations per second. If the language has to figure out what type something is while it's running (like Lua does), that takes extra time. By knowing the types upfront, Lyte can *compile* — translate your code into fast machine instructions — more efficiently. **Compile** just means the step where your written code gets translated into something the computer can actually run directly.
+In audio DSP, you are doing a lot of math very quickly. If the language has to keep figuring out what kind of value something is while it runs, that adds overhead. By knowing the types up front, Lyte can build faster code. Here, **compile** just means “turn your code into something the computer can run.”
 
-It also catches mistakes *before* they cause weird audio glitches. Instead of a bug silently producing wrong output, Lyte just refuses to compile and tells you what went wrong.
+It also catches many mistakes before they turn into weird behavior or broken audio. Instead of running bad code, Lyte stops and tells you what went wrong.
 
 For example, assigning an `f32` value to an `i32` variable is a type error:
 
@@ -118,24 +125,54 @@ The phrase "no solution for X == Y" is Lyte's general way of saying "I couldn't 
 ## 3. Your First Program — Hello World
 
 ```lyte
-main {
-    println("hello world")
+init {}
+
+process {
+    for i in 0 .. frames {
+        output[i] = input[i]
+    }
+    println("Hello world!")
 }
 ```
 
 A few things to notice right away:
 
-**`main` is a special block, not a function.** In many languages, `main` is a function you have to define carefully. In Lyte, it's just a block of code — the starting point of your program. No parentheses, no return type, just `main { ... }`.
+**In an Audulus DSP node, `process` is where the audio work happens.** This example passes the input straight to the output, then prints a simple debug message once per processing block.
 
-**`println` prints text to the output.** It's a built-in function. You pass it a string (text in quotes) and it prints it.
+**`println` prints strings.** A plain text message is the simplest way to test that debug output is working.
 
-**Comments use `//`.** Anything after `//` on a line is ignored by Lyte — it's just a note for the reader.
+**Comments use `//`.** Anything after `//` on a line is ignored by Lyte. It is just a note for the reader.
 
-> 🔄 *Lua users: Lua comments use `--` instead of `//`.*
+Note for Lua users: Lua comments use `--` instead of `//`.
 
 ```lyte
-main {
-    println("hello world")   // this is a comment
+init {}
+
+process {
+    for i in 0 .. frames {
+        output[i] = input[i]
+    }
+    println("Hello world!")   // this is a comment
+}
+```
+
+If you want to print a changing number, use a small counter and convert it to text:
+
+```lyte
+var calls: i32
+
+init {}
+
+process {
+    var buf: [i8; 16]
+
+    for i in 0 .. frames {
+        output[i] = input[i]
+    }
+
+    itoa(buf, calls)
+    println(buf)
+    calls = calls + 1
 }
 ```
 
@@ -143,25 +180,25 @@ main {
 
 ## 4. Variables — `var` and `let`
 
-Lyte has two ways to create a variable, and they have an important difference:
+Lyte has two ways to create a variable, and the difference is simple:
 
 ```lyte
 main {
-    var x = 42      // mutable (changeable): x can be reassigned later
-    let y = x + 1   // immutable (fixed): y can never be changed
+    var x = 42      // can change later
+    let y = x + 1   // stays fixed after this line
 }
 ```
 
-- **`var`** = the value *can* change (*mutable* is the technical term for this — it just means "able to be changed"). Use this when you need to update something (like a running total, or a signal value).
-- **`let`** = the value *cannot* change after it's set (*immutable* — unable to be changed). Use this when something is fixed.
+- **`var`** = the value can change later
+- **`let`** = the value stays fixed after you set it
 
 ### Why have two kinds?
 
-This is a safety feature. If you mark something as `let`, Lyte guarantees it will never be accidentally overwritten. In complex DSP code with lots of variables, this helps prevent subtle bugs.
+This helps prevent mistakes. If something is written as `let`, Lyte knows it should not change later.
 
 ### Type inference
 
-Notice that in the examples above, we didn't write the type — Lyte figured it out automatically. `var x = 42` — Lyte sees `42` and knows `x` must be an `i32`. This is called **type inference**.
+Notice that in the examples above, we did not write the type. Lyte figured it out automatically. `var x = 42` means Lyte sees `42` and knows `x` must be an `i32`. This is called **type inference**.
 
 You *can* write the type explicitly if you want, and sometimes you have to (when declaring a variable without immediately giving it a value):
 
@@ -172,7 +209,7 @@ x = 10
 signal = 0.5
 ```
 
-When you declare a variable without a value, it is **zero-initialized** — numeric types start at `0`, `f32` starts at `0.0`, booleans start at `false`, and struct fields all start at their zero values too. This is confirmed behavior, not something you have to guess about:
+When you declare a variable without a value, Lyte starts it at zero. Numbers start at `0` or `0.0`, booleans start at `false`, and struct fields start at their own zero values too:
 
 ```lyte
 main {
@@ -181,11 +218,11 @@ main {
 }
 ```
 
-This is a meaningful safety guarantee. In some lower-level languages (like C), declaring a variable without a value leaves it containing whatever random data happened to be in that memory location. Lyte never does that.
+This is a useful safety feature. You do not get random leftover memory values.
 
 ### Variable shadowing
 
-You can declare a new variable with the same name as an existing one inside an inner block (like a loop or `if` body). The inner variable **shadows** the outer one — inside the block, the name refers to the new variable, not the original:
+You can declare a new variable with the same name inside an inner block, like a loop or an `if`. Inside that block, the new variable temporarily takes over the name:
 
 ```lyte
 main {
@@ -197,13 +234,13 @@ main {
 }
 ```
 
-The outer `x` is unaffected. This is confirmed valid — Lyte does not treat it as an error.
+The outer `x` is unchanged. Lyte allows this, but it can be confusing, so use it carefully.
 
 ---
 
 ### Global variables
 
-A variable declared outside of any function or `main` block is a **global** — it exists for the entire lifetime of the program and is accessible from any function:
+A variable declared outside of any function or `main` block is a **global**. It exists for the whole program and any function can use it:
 
 ```lyte
 var global: i32
@@ -219,9 +256,9 @@ main {
 }
 ```
 
-Global variables must be declared with an explicit type (`var global: i32`, not `var global = 0`). They are zero-initialized by default, just like local variables. Any function can access them by name — no special keyword needed.
+Global variables must be declared with an explicit type (`var global: i32`, not `var global = 0`). Like local variables, they start at zero. Any function can access them by name.
 
-In Audulus DSP nodes, globals are the natural place to store persistent state between processing blocks — things like filter memory, oscillator phase, or envelope position. Named ports are also exposed as globals, and DSP code typically loops over `frames` inside `process`.
+In Audulus DSP nodes, globals are the normal place to store state that must survive between processing blocks, such as filter memory, oscillator phase, or envelope position. Named ports also appear as globals, and DSP code usually loops over `frames` inside `process`.
 
 ---
 
@@ -243,9 +280,9 @@ main {
 }
 ```
 
-No `then` keyword, no `end` keyword — curly braces `{ }` mark the beginning and end of blocks. Parentheses around the condition are optional.
+There is no `then` and no `end`. Curly braces `{ }` mark the block. Parentheses around the condition are optional.
 
-> 🔄 *Lua users: Lyte uses `{ }` instead of `then`/`end`. `if x > 0 { }` in Lyte vs `if x > 0 then ... end` in Lua.*
+Note for Lua users: Lyte uses `{ }` instead of `then` and `end`.
 
 ### For loops
 
@@ -258,9 +295,9 @@ main {
 }
 ```
 
-The `0 .. 10` is a **range**. It means "from 0 up to but not including 10" — so it goes 0, 1, 2, 3, 4, 5, 6, 7, 8, 9. This is called an *exclusive* range (the end value is excluded).
+The `0 .. 10` is a range. It means "from 0 up to but not including 10" — so it goes 0, 1, 2, 3, 4, 5, 6, 7, 8, 9.
 
-> 🔄 *Lua users: Lyte's `for i in 0 .. 10 { }` is equivalent to Lua's `for i = 0, 9 do ... end`. Different syntax, same idea — though note Lyte's range excludes the end value.*
+Note for Lua users: `for i in 0 .. 10 { }` is similar to `for i = 0, 9 do ... end`.
 
 `i` is automatically created as the loop variable — you don't need `var i` beforehand.
 
@@ -345,7 +382,7 @@ This is called **overloading** — the same name, different types.
 
 A **struct** is a way to bundle related pieces of data into a single named unit.
 
-> 🔄 *Lua users: In Lua you'd use a table for this — `point = { x = 3.0, y = 4.0 }`. Lyte's structs serve the same purpose but with fixed, declared fields and types — you can't add new fields at runtime.*
+Note for Lua users: in Lua you would usually use a table for this, like `point = { x = 3.0, y = 4.0 }`. Lyte structs fill a similar role, but the fields and their types are fixed.
 
 Imagine you're working with a 2D point. It has an X coordinate and a Y coordinate. Instead of keeping two separate variables, you can define a struct:
 
@@ -385,7 +422,7 @@ main {
 }
 ```
 
-`sqrtf` is a built-in function that computes a square root. The `f` at the end stands for float — it works on `f32` values.
+`sqrt` is a built-in function that computes a square root.
 
 ---
 
@@ -393,7 +430,7 @@ main {
 
 Lyte lets you define exactly what `+`, `-`, `*`, and other operators mean for your custom types. This is called **operator overloading**.
 
-> 🔄 *Lua users: Lua supports this via metatables — the `__add`, `__mul` naming convention in Lyte is borrowed directly from Lua's metatable approach, so the names will look familiar.*
+Note for Lua users: this is similar in spirit to Lua metatables. Names like `__add` and `__mul` will probably look familiar.
 
 You do it by defining special functions with names like `__add`, `__sub`, `__mul`:
 
@@ -531,7 +568,7 @@ main {
 
 An **array** is an ordered list of values, all of the same type. In Lyte, arrays have a **fixed size** — you decide the size when you create the array, and it never changes.
 
-> 🔄 *Lua users: Lua tables can grow and shrink freely. Lyte's fixed-size arrays are a deliberate constraint — because the size is always known in advance, the language can make stronger safety guarantees and run faster.*
+Note for Lua users: Lua tables can grow and shrink. Lyte arrays have a fixed size.
 
 ```lyte
 main {
@@ -543,7 +580,7 @@ main {
 
 **Indexing starts at 0** — the first element is `a[0]`, the second is `a[1]`, and so on. This is standard in most programming languages.
 
-> 🔄 *Lua users: Lua starts at 1, so `a[1]` is the first element. In Lyte, as in most other languages, `a[0]` is first.*
+Note for Lua users: Lua starts at `1`, but Lyte starts at `0`.
 
 To declare an array with a specific type and size without filling it in right away:
 
@@ -614,7 +651,7 @@ main {
 
 This also applies when arrays are inside structs — assigning a struct copies the whole thing, including any arrays it contains.
 
-> 🔄 *Lua users: Lua tables are passed by reference — multiple variables can point to the same table, and changing one changes all of them. Lyte's copy-by-value behavior is the opposite: each variable owns its own data independently.*
+Note for Lua users: Lua tables are shared by reference. Lyte arrays are copied by value, so changing one copy does not change the other.
 
 ### Arrays inside structs
 
@@ -1198,7 +1235,7 @@ This helper takes a `Biquad` state and one input sample `x`, and returns a **tup
 - loop over `for i in 0 .. frames` inside `process`
 - use the block buffers (`input[i]`, `output[i]`) directly
 
-So this section is best read as the language idea behind a biquad. For current Audulus-ready code, the quickstart examples are the better reference.
+So this section is best read as the language idea behind a biquad. For practical Audulus node code, the quickstart examples are the better reference.
 
 > *Aside — why this runs efficiently: the multiply-add chains in the biquad formula (like `b0*x + b1*x1`) map directly to a hardware instruction called FMA, or fused multiply-add, which performs a multiplication and an addition in a single step rather than two. Lyte's compiler targets these instructions automatically when generating code for this kind of expression, which is one reason DSP code in Lyte can run efficiently.*
 
@@ -1379,11 +1416,16 @@ main {
 }
 ```
 
-> 🔄 *Lua users: Lua strings are immutable and managed automatically — you can't index into them and change individual characters. In Lyte, a string is just an array of `i8` values that you can read and write directly.*
+Note for Lua users: Lua strings cannot be changed in place. In Lyte, a string is just an array of `i8` values, so you can read and write individual characters.
 
-### Math functions (built into the language)
+### Math functions
 
-These functions are available without any setup — they're part of Lyte itself, not defined in `stdlib.lyte`. Their names follow the same unsuffixed style used by the Audulus Expr node: `sin`, `cos`, `atan2`, and so on.
+Lyte math comes from two places:
+
+- core builtins that are part of the language itself, such as `sin`, `cos`, `tan`, `atan2`, `sqrt`, `floor`, and `ceil`
+- helper functions from `stdlib.lyte`, such as `clamp`, `mix`, `fract`, `mod`, `step`, and `smoothstep`
+
+The function names follow the same unsuffixed style used by the Audulus Expr node: `sin`, `cos`, `atan2`, and so on.
 
 Unary math functions (`f32`/`f64` in, same type out):
 
@@ -1432,8 +1474,21 @@ This list is confirmed against the compiler and test suite. A few notes:
 - `ln` and `exp` are inverses: `ln(exp(x))` gives back `x`.
 - `atan2` takes **two** arguments — `y` first, then `x`. This is the standard convention for two-argument arctangent, useful for converting Cartesian coordinates to an angle.
 - `isinf` and `isnan` currently return an integer flag rather than a `bool`, so the tests use checks like `isnan(x) != 0`.
-- `pi` is not a built-in constant in current Audulus Lyte. If you want it, define your own `var pi: f32` and set it to `3.14159265`.
+- `pi` is not a built-in constant in Audulus Lyte. If you want it, define your own `var pi: f32` and set it to `3.14159265`.
 - These map directly to compiler/runtime intrinsics, so they're fast.
+
+Here are some common math helpers from `stdlib.lyte`:
+
+| Function | What it does |
+|----------|--------------|
+| `fract(x)` | Fractional part of `x` |
+| `mod(x, y)` | Floating-point modulo |
+| `clamp(x, lo, hi)` | Clamp `x` into a range |
+| `step(edge, x)` | `0` below the edge, `1` at or above it |
+| `smoothstep(edge0, edge1, x)` | Smooth curve between two edges |
+| `mix(a, b, t)` | Blend from `a` to `b` by amount `t` |
+
+One small difference from the Audulus Expr node: Lyte uses `mix(a, b, t)`, while Audulus Expr uses `mix(x, a, b)`.
 
 ### String functions (from `stdlib.lyte`)
 
@@ -1513,7 +1568,7 @@ Appends one string onto the end of another. For example, if `dst` contains `"hel
 
 ### A note on what's not here
 
-The stdlib is intentionally small. There's no separate math library defined in Lyte code — built-in math functions like `sin` and `cos` are handled directly by the compiler. `putc` is similarly built-in, sitting one level below `println`. For DSP work, the math you need is built in; the stdlib is mainly there to help with text output and debugging.
+The stdlib is still fairly small, but it does include useful math helpers as well as string utilities. Core functions like `sin`, `cos`, and `sqrt` are handled directly by the compiler, while helpers like `clamp`, `mix`, and `smoothstep` live in `stdlib.lyte`. `putc` is also built in, sitting one level below `println`.
 
 ---
 
@@ -1658,6 +1713,55 @@ Any type mismatch on assignment — not just `i32`/`f32` — produces the same e
 ```
 
 The left side of `==` in the message is always the *expected* type (the variable's declared type); the right side is the *actual* type of the value you tried to assign.
+
+### Inline `if` expressions can cause misleading parser errors
+
+In Lyte, block-form inline `if` expressions are not reliable in every context. Patterns like these can cause a long chain of parser errors:
+
+```lyte
+let x = if cond {
+    a
+} else {
+    b
+}
+```
+
+```lyte
+output[i] = if cond {
+    a
+} else {
+    b
+}
+```
+
+You may see messages like:
+
+```
+Expected expression
+Expected declaration, got Let
+Expected declaration, got Assign
+Expected declaration, got Lbracket
+```
+
+The safer pattern is:
+
+```lyte
+var x = b
+if cond {
+    x = a
+}
+```
+
+Or for an output:
+
+```lyte
+output[i] = b
+if cond {
+    output[i] = a
+}
+```
+
+This is a little more verbose, but it is much more dependable in current Lyte.
 
 ### Calling an undefined macro
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -904,6 +904,17 @@ impl Compiler {
         Ok(vm.run(&program))
     }
 
+    /// Run the code using the 16-bit VM interpreter.
+    pub fn run_vm16(&mut self) -> Result<i64, String> {
+        let program = self.compile_vm()?;
+        let func_idx = *program
+            .entry_points
+            .get(&Name::str("main"))
+            .ok_or("no main entry point")?;
+        let mut vm = crate::vm16::VM16::new();
+        Ok(vm.run(&program, func_idx, &[]))
+    }
+
     /// Compile to a backend-agnostic CompiledProgram.
     /// Auto-selects LLVM JIT (when available) or VM.
     pub fn compile_program(&self) -> Result<CompiledProgram, String> {
@@ -2395,5 +2406,75 @@ mod tests {
             LLVM_SEND_CALLED.load(Ordering::SeqCst),
             "send() was not called"
         );
+    }
+
+    // ---- VM16 integration tests ----
+
+    fn run_vm16(code: &str) {
+        let mut compiler = Compiler::new();
+        compiler.parse(code.into(), ".");
+        assert!(compiler.check(), "type check failed");
+        compiler.specialize().unwrap();
+        compiler.run_vm16().expect("VM16 execution failed");
+    }
+
+    #[test]
+    fn test_vm16_basic() {
+        run_vm16(r#"
+            main {
+                var x = 42
+                assert(x == 42)
+            }
+        "#);
+    }
+
+    #[test]
+    fn test_vm16_arithmetic() {
+        run_vm16(r#"
+            main {
+                var a = 3
+                var b = 4
+                var c = a + b
+                assert(c == 7)
+                assert(a * b == 12)
+                assert(b - a == 1)
+            }
+        "#);
+    }
+
+    #[test]
+    fn test_vm16_loop() {
+        run_vm16(r#"
+            main {
+                var sum = 0
+                for i in 0 .. 10 {
+                    sum = sum + i
+                }
+                assert(sum == 45)
+            }
+        "#);
+    }
+
+    #[test]
+    fn test_vm16_float() {
+        // Simple float test without function calls.
+        run_vm16(r#"
+            main {
+                var x: f32 = 25.0
+                var y = sqrt(x)
+                // y should be 5.0, truncate to int
+                var z = y as i32
+                assert(z == 5)
+            }
+        "#);
+    }
+
+    #[test]
+    fn test_vm16_print() {
+        run_vm16(r#"
+            main {
+                print(123)
+            }
+        "#);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,3 +91,7 @@ pub mod stack_rebase_lm;
 pub mod stack_interp_bridge;
 
 pub mod ffi;
+pub mod vm16_opcode;
+pub mod vm16_lower;
+pub mod vm16_link;
+pub mod vm16;

--- a/src/vm16.rs
+++ b/src/vm16.rs
@@ -1,0 +1,960 @@
+//! 16-bit VM interpreter with 16 registers.
+//!
+//! Dispatch loop uses a 256-entry match on the opcode byte.
+//! Registers are indexed by the 4-bit rA/rB fields extracted from the 16-bit word.
+//! In the ARM64 assembly backend (Phase 3), registers will be pinned to CPU registers
+//! and the full 65K jump table will be used.
+
+use crate::opcode::FuncIdx;
+use crate::vm::{self, ExternFuncInfo, VMProgram, println_output, print_output};
+use crate::vm16_link::LinkedProgram16;
+use crate::vm16_lower;
+use crate::vm16_opcode::tags;
+
+/// Call frame for function execution.
+#[derive(Clone, Debug)]
+struct CallFrame {
+    func_idx: FuncIdx,
+    ip: usize,
+    locals_base: usize,
+}
+
+/// 16-bit VM with 16 general-purpose 64-bit registers.
+pub struct VM16 {
+    pub regs: [u64; 16],
+    pub locals: Vec<u8>,
+    pub globals: Vec<u8>,
+    call_stack: Vec<CallFrame>,
+    current_func: FuncIdx,
+    locals_base: usize,
+    pub cancelled: bool,
+}
+
+impl VM16 {
+    pub fn new() -> Self {
+        Self {
+            regs: [0u64; 16],
+            locals: vec![0u8; 1024 * 1024], // 1MB default
+            globals: Vec::new(),
+            call_stack: Vec::new(),
+            current_func: 0,
+            locals_base: 0,
+            cancelled: false,
+        }
+    }
+
+    /// Compile a VMProgram to 16-bit format and run a function.
+    pub fn run(&mut self, program: &VMProgram, func_idx: FuncIdx, args: &[i64]) -> i64 {
+        // Extract function info from VMProgram.
+        let functions: Vec<_> = program
+            .functions
+            .iter()
+            .map(|f| (f.code.clone(), f.param_count, f.locals_size))
+            .collect();
+
+        let lowered = vm16_lower::lower_program(&functions);
+        let linked = LinkedProgram16::from_lowered(&lowered);
+
+        if self.globals.is_empty() && program.globals_size > 0 {
+            self.globals = vec![0u8; program.globals_size];
+        }
+
+        self.run_linked(&linked, program, func_idx, args)
+    }
+
+    /// Run with a pre-linked program.
+    pub fn run_linked(
+        &mut self,
+        linked: &LinkedProgram16,
+        program: &VMProgram,
+        func_idx: FuncIdx,
+        args: &[i64],
+    ) -> i64 {
+        // Set up initial state.
+        self.regs = [0u64; 16];
+        for (i, &arg) in args.iter().enumerate().take(16) {
+            self.regs[i] = arg as u64;
+        }
+        self.current_func = func_idx;
+        self.call_stack.clear();
+        self.locals_base = 0;
+        self.cancelled = false;
+
+        // Pin hot state to local variables for performance.
+        let ops = linked.ops.as_ptr();
+        let ops_len = linked.ops.len();
+        let mut ip = linked.func_offsets[func_idx as usize];
+        let mut locals_base = 0usize;
+
+        // Allocate initial locals.
+        let needed = linked.func_locals[func_idx as usize] as usize;
+        if needed > self.locals.len() {
+            self.locals.resize(needed * 2, 0);
+        }
+        // Zero locals for current frame.
+        for b in &mut self.locals[0..needed] {
+            *b = 0;
+        }
+
+        loop {
+            if ip >= ops_len {
+                return self.regs[0] as i64;
+            }
+
+            let word = unsafe { *ops.add(ip) };
+            ip += 1;
+            let opcode = (word >> 8) as u8;
+            let ra = ((word >> 4) & 0xF) as usize;
+            let rb = (word & 0xF) as usize;
+
+            macro_rules! trail {
+                () => {{
+                    let t = unsafe { *ops.add(ip) };
+                    ip += 1;
+                    t
+                }};
+            }
+
+            macro_rules! trail_i16 {
+                () => {
+                    trail!() as i16
+                };
+            }
+
+            macro_rules! r {
+                ($idx:expr) => {
+                    self.regs[$idx]
+                };
+            }
+
+            macro_rules! r_i32 {
+                ($idx:expr) => {
+                    self.regs[$idx] as i32
+                };
+            }
+
+            macro_rules! r_f32 {
+                ($idx:expr) => {
+                    f32::from_bits(self.regs[$idx] as u32)
+                };
+            }
+
+            macro_rules! r_f64 {
+                ($idx:expr) => {
+                    f64::from_bits(self.regs[$idx])
+                };
+            }
+
+            macro_rules! set_i32 {
+                ($idx:expr, $val:expr) => {
+                    self.regs[$idx] = ($val as i32) as u32 as u64;
+                };
+            }
+
+            macro_rules! set_f32 {
+                ($idx:expr, $val:expr) => {
+                    self.regs[$idx] = f32::to_bits($val) as u64;
+                };
+            }
+
+            macro_rules! set_f64 {
+                ($idx:expr, $val:expr) => {
+                    self.regs[$idx] = f64::to_bits($val);
+                };
+            }
+
+            macro_rules! set_i64 {
+                ($idx:expr, $val:expr) => {
+                    self.regs[$idx] = $val as u64;
+                };
+            }
+
+            macro_rules! local_ptr {
+                ($slot:expr) => {
+                    unsafe { self.locals.as_ptr().add(locals_base + ($slot as usize) * 8) }
+                };
+            }
+
+            macro_rules! local_ptr_mut {
+                ($slot:expr) => {
+                    unsafe { self.locals.as_mut_ptr().add(locals_base + ($slot as usize) * 8) }
+                };
+            }
+
+            unsafe {
+                match opcode {
+                    tags::NOP => {}
+
+                    tags::HALT => return r!(0) as i64,
+
+                    tags::RETURN => {
+                        if self.call_stack.is_empty() {
+                            return r!(0) as i64;
+                        }
+                        let frame = self.call_stack.pop().unwrap();
+                        self.current_func = frame.func_idx;
+                        ip = frame.ip;
+                        locals_base = frame.locals_base;
+                    }
+
+                    tags::RETURN_REG => {
+                        if ra != 0 {
+                            r![0] = r![ra];
+                        }
+                        if self.call_stack.is_empty() {
+                            return r!(0) as i64;
+                        }
+                        let frame = self.call_stack.pop().unwrap();
+                        self.current_func = frame.func_idx;
+                        ip = frame.ip;
+                        locals_base = frame.locals_base;
+                    }
+
+                    tags::JUMP => {
+                        let offset = trail_i16!();
+                        ip = (ip as isize + offset as isize) as usize;
+                    }
+
+                    tags::JUMP_IF_ZERO => {
+                        let offset = trail_i16!();
+                        if r_i32!(ra) == 0 {
+                            ip = (ip as isize + offset as isize) as usize;
+                        }
+                    }
+
+                    tags::JUMP_IF_NOT_ZERO => {
+                        let offset = trail_i16!();
+                        if r_i32!(ra) != 0 {
+                            ip = (ip as isize + offset as isize) as usize;
+                        }
+                    }
+
+                    // === Moves & Loads ===
+                    tags::MOVE => { r![ra] = r![rb]; }
+
+                    tags::LOAD_IMM => {
+                        let val = trail_i16!() as i64;
+                        set_i64!(ra, val);
+                    }
+
+                    tags::LOAD_IMM_WIDE => {
+                        let idx = trail!() as usize;
+                        set_i64!(ra, linked.i64_pool[idx]);
+                    }
+
+                    tags::LOAD_F32 => {
+                        let idx = trail!() as usize;
+                        set_f32!(ra, linked.f32_pool[idx]);
+                    }
+
+                    tags::LOAD_F64 => {
+                        let idx = trail!() as usize;
+                        set_f64!(ra, linked.f64_pool[idx]);
+                    }
+
+                    tags::LOAD_CONST => {
+                        let _idx = trail!();
+                        // TODO: constant pool
+                    }
+
+                    tags::LOCAL_ADDR => {
+                        let slot = trail!() as usize;
+                        let addr = self.locals.as_ptr().add(locals_base + slot * 8);
+                        set_i64!(ra, addr as i64);
+                    }
+
+                    tags::GLOBAL_ADDR => {
+                        let offset = trail!() as usize;
+                        let addr = self.globals.as_ptr().add(offset);
+                        set_i64!(ra, addr as i64);
+                    }
+
+                    tags::GET_CLOSURE_PTR => {
+                        // TODO: closures
+                        set_i64!(ra, 0);
+                    }
+
+                    // === Integer Arithmetic (destructive) ===
+                    tags::IADD => { set_i32!(ra, r_i32!(ra).wrapping_add(r_i32!(rb))); }
+                    tags::ISUB => { set_i32!(ra, r_i32!(ra).wrapping_sub(r_i32!(rb))); }
+                    tags::IMUL => { set_i32!(ra, r_i32!(ra).wrapping_mul(r_i32!(rb))); }
+                    tags::IDIV => {
+                        let b = r_i32!(rb);
+                        set_i32!(ra, if b != 0 { r_i32!(ra) / b } else { 0 });
+                    }
+                    tags::UDIV => {
+                        let b = r!(rb) as u32;
+                        set_i32!(ra, if b != 0 { (r!(ra) as u32 / b) as i32 } else { 0 });
+                    }
+                    tags::IREM => {
+                        let b = r_i32!(rb);
+                        set_i32!(ra, if b != 0 { r_i32!(ra) % b } else { 0 });
+                    }
+                    tags::IPOW => {
+                        let base = r_i32!(ra);
+                        let exp = r_i32!(rb);
+                        set_i32!(ra, i32_pow(base, exp));
+                    }
+                    tags::INEG => { set_i32!(ra, -r_i32!(ra)); }
+                    tags::IADD_IMM => {
+                        let imm = trail_i16!() as i32;
+                        set_i32!(ra, r_i32!(ra).wrapping_add(imm));
+                    }
+
+                    // === Float32 Arithmetic ===
+                    tags::FADD => { set_f32!(ra, r_f32!(ra) + r_f32!(rb)); }
+                    tags::FSUB => { set_f32!(ra, r_f32!(ra) - r_f32!(rb)); }
+                    tags::FMUL => { set_f32!(ra, r_f32!(ra) * r_f32!(rb)); }
+                    tags::FDIV => { set_f32!(ra, r_f32!(ra) / r_f32!(rb)); }
+                    tags::FNEG => { set_f32!(ra, -r_f32!(ra)); }
+                    tags::FPOW => { set_f32!(ra, r_f32!(ra).powf(r_f32!(rb))); }
+
+                    tags::FMUL_ADD => {
+                        let rc = (trail!() & 0xF) as usize;
+                        set_f32!(ra, r_f32!(ra) * r_f32!(rb) + r_f32!(rc));
+                    }
+                    tags::FMUL_SUB => {
+                        let rc = (trail!() & 0xF) as usize;
+                        set_f32!(ra, r_f32!(ra) * r_f32!(rb) - r_f32!(rc));
+                    }
+                    tags::FNMUL_ADD => {
+                        let rc = (trail!() & 0xF) as usize;
+                        set_f32!(ra, r_f32!(rc) - r_f32!(ra) * r_f32!(rb));
+                    }
+
+                    // === Float64 Arithmetic ===
+                    tags::DADD => { set_f64!(ra, r_f64!(ra) + r_f64!(rb)); }
+                    tags::DSUB => { set_f64!(ra, r_f64!(ra) - r_f64!(rb)); }
+                    tags::DMUL => { set_f64!(ra, r_f64!(ra) * r_f64!(rb)); }
+                    tags::DDIV => { set_f64!(ra, r_f64!(ra) / r_f64!(rb)); }
+                    tags::DNEG => { set_f64!(ra, -r_f64!(ra)); }
+                    tags::DPOW => { set_f64!(ra, r_f64!(ra).powf(r_f64!(rb))); }
+
+                    tags::DMUL_ADD => {
+                        let rc = (trail!() & 0xF) as usize;
+                        set_f64!(ra, r_f64!(ra) * r_f64!(rb) + r_f64!(rc));
+                    }
+                    tags::DMUL_SUB => {
+                        let rc = (trail!() & 0xF) as usize;
+                        set_f64!(ra, r_f64!(ra) * r_f64!(rb) - r_f64!(rc));
+                    }
+                    tags::DNMUL_ADD => {
+                        let rc = (trail!() & 0xF) as usize;
+                        set_f64!(ra, r_f64!(rc) - r_f64!(ra) * r_f64!(rb));
+                    }
+
+                    // === Bitwise ===
+                    tags::AND => { set_i32!(ra, r_i32!(ra) & r_i32!(rb)); }
+                    tags::OR => { set_i32!(ra, r_i32!(ra) | r_i32!(rb)); }
+                    tags::XOR => { set_i32!(ra, r_i32!(ra) ^ r_i32!(rb)); }
+                    tags::NOT => { set_i32!(ra, if r_i32!(ra) != 0 { 0 } else { 1 }); }
+                    tags::SHL => { set_i32!(ra, r_i32!(ra) << (r_i32!(rb) & 31)); }
+                    tags::SHR => { set_i32!(ra, r_i32!(ra) >> (r_i32!(rb) & 31)); }
+                    tags::USHR => { set_i32!(ra, ((r!(ra) as u32) >> (r_i32!(rb) as u32 & 31)) as i32); }
+
+                    // === Comparisons ===
+                    tags::IEQ => { set_i32!(ra, if r_i32!(ra) == r_i32!(rb) { 1 } else { 0 }); }
+                    tags::INE => { set_i32!(ra, if r_i32!(ra) != r_i32!(rb) { 1 } else { 0 }); }
+                    tags::ILT => { set_i32!(ra, if r_i32!(ra) < r_i32!(rb) { 1 } else { 0 }); }
+                    tags::ILE => { set_i32!(ra, if r_i32!(ra) <= r_i32!(rb) { 1 } else { 0 }); }
+                    tags::ULT => { set_i32!(ra, if (r!(ra) as u32) < (r!(rb) as u32) { 1 } else { 0 }); }
+                    tags::FEQ => { set_i32!(ra, if r_f32!(ra) == r_f32!(rb) { 1 } else { 0 }); }
+                    tags::FNE => { set_i32!(ra, if r_f32!(ra) != r_f32!(rb) { 1 } else { 0 }); }
+                    tags::FLT => { set_i32!(ra, if r_f32!(ra) < r_f32!(rb) { 1 } else { 0 }); }
+                    tags::FLE => { set_i32!(ra, if r_f32!(ra) <= r_f32!(rb) { 1 } else { 0 }); }
+                    tags::DEQ => { set_i32!(ra, if r_f64!(ra) == r_f64!(rb) { 1 } else { 0 }); }
+                    tags::DLT => { set_i32!(ra, if r_f64!(ra) < r_f64!(rb) { 1 } else { 0 }); }
+                    tags::DLE => { set_i32!(ra, if r_f64!(ra) <= r_f64!(rb) { 1 } else { 0 }); }
+
+                    // === Fused compare+branch (non-destructive) ===
+                    tags::ILT_JUMP => {
+                        let offset = trail_i16!();
+                        if !(r_i32!(ra) < r_i32!(rb)) {
+                            ip = (ip as isize + offset as isize) as usize;
+                        }
+                    }
+                    tags::FLT_JUMP => {
+                        let offset = trail_i16!();
+                        if !(r_f32!(ra) < r_f32!(rb)) {
+                            ip = (ip as isize + offset as isize) as usize;
+                        }
+                    }
+                    tags::ILE_JUMP => {
+                        let offset = trail_i16!();
+                        if !(r_i32!(ra) <= r_i32!(rb)) {
+                            ip = (ip as isize + offset as isize) as usize;
+                        }
+                    }
+                    tags::FLE_JUMP => {
+                        let offset = trail_i16!();
+                        if !(r_f32!(ra) <= r_f32!(rb)) {
+                            ip = (ip as isize + offset as isize) as usize;
+                        }
+                    }
+
+                    // === Type Conversions ===
+                    tags::I32_TO_F32 => { set_f32!(ra, r_i32!(ra) as f32); }
+                    tags::F32_TO_I32 => { set_i32!(ra, r_f32!(ra) as i32); }
+                    tags::I32_TO_F64 => { set_f64!(ra, r_i32!(ra) as f64); }
+                    tags::F64_TO_I32 => { set_i32!(ra, r_f64!(ra) as i32); }
+                    tags::F32_TO_F64 => { set_f64!(ra, r_f32!(ra) as f64); }
+                    tags::F64_TO_F32 => { set_f32!(ra, r_f64!(ra) as f32); }
+                    tags::I32_TO_I8 => { set_i32!(ra, r_i32!(ra) as i8 as i32); }
+                    tags::I8_TO_I32 => { set_i32!(ra, r_i32!(ra) as i8 as i32); }
+                    tags::I64_TO_U32 => { set_i32!(ra, (r!(ra) as u32) as i32); }
+
+                    // === Memory: basic ===
+                    tags::LOAD8 => {
+                        let addr = r!(rb) as *const u8;
+                        set_i32!(ra, *addr as i8 as i32);
+                    }
+                    tags::LOAD32 => {
+                        let addr = r!(rb) as *const u32;
+                        r![ra] = *addr as u64;
+                    }
+                    tags::LOAD64 => {
+                        let addr = r!(rb) as *const u64;
+                        r![ra] = *addr;
+                    }
+                    tags::STORE8 => {
+                        let addr = r!(ra) as *mut u8;
+                        *addr = r!(rb) as u8;
+                    }
+                    tags::STORE32 => {
+                        let addr = r!(ra) as *mut u32;
+                        *addr = r!(rb) as u32;
+                    }
+                    tags::STORE64 => {
+                        let addr = r!(ra) as *mut u64;
+                        *addr = r!(rb);
+                    }
+
+                    // === Memory: with trailing offset ===
+                    tags::LOAD32_OFF => {
+                        let offset = trail_i16!() as isize;
+                        let addr = (r!(rb) as *const u8).offset(offset) as *const u32;
+                        r![ra] = *addr as u64;
+                    }
+                    tags::LOAD64_OFF => {
+                        let offset = trail_i16!() as isize;
+                        let addr = (r!(rb) as *const u8).offset(offset) as *const u64;
+                        r![ra] = *addr;
+                    }
+                    tags::STORE8_OFF => {
+                        let offset = trail_i16!() as isize;
+                        let addr = (r!(ra) as *mut u8).offset(offset);
+                        *addr = r!(rb) as u8;
+                    }
+                    tags::STORE32_OFF => {
+                        let offset = trail_i16!() as isize;
+                        let addr = (r!(ra) as *mut u8).offset(offset) as *mut u32;
+                        *addr = r!(rb) as u32;
+                    }
+                    tags::STORE64_OFF => {
+                        let offset = trail_i16!() as isize;
+                        let addr = (r!(ra) as *mut u8).offset(offset) as *mut u64;
+                        *addr = r!(rb);
+                    }
+
+                    // === Memory: offset-encoded Load32 ===
+                    tags::LOAD32_OFF0 => { r![ra] = *((r!(rb) as *const u8).add(0) as *const u32) as u64; }
+                    tags::LOAD32_OFF4 => { r![ra] = *((r!(rb) as *const u8).add(4) as *const u32) as u64; }
+                    tags::LOAD32_OFF8 => { r![ra] = *((r!(rb) as *const u8).add(8) as *const u32) as u64; }
+                    tags::LOAD32_OFF12 => { r![ra] = *((r!(rb) as *const u8).add(12) as *const u32) as u64; }
+                    tags::LOAD32_OFF16 => { r![ra] = *((r!(rb) as *const u8).add(16) as *const u32) as u64; }
+                    tags::LOAD32_OFF20 => { r![ra] = *((r!(rb) as *const u8).add(20) as *const u32) as u64; }
+                    tags::LOAD32_OFF24 => { r![ra] = *((r!(rb) as *const u8).add(24) as *const u32) as u64; }
+                    tags::LOAD32_OFF28 => { r![ra] = *((r!(rb) as *const u8).add(28) as *const u32) as u64; }
+                    tags::LOAD32_OFF32 => { r![ra] = *((r!(rb) as *const u8).add(32) as *const u32) as u64; }
+
+                    // === Memory: offset-encoded Store32 ===
+                    tags::STORE32_OFF0 => { *((r!(ra) as *mut u8).add(0) as *mut u32) = r!(rb) as u32; }
+                    tags::STORE32_OFF4 => { *((r!(ra) as *mut u8).add(4) as *mut u32) = r!(rb) as u32; }
+                    tags::STORE32_OFF8 => { *((r!(ra) as *mut u8).add(8) as *mut u32) = r!(rb) as u32; }
+                    tags::STORE32_OFF12 => { *((r!(ra) as *mut u8).add(12) as *mut u32) = r!(rb) as u32; }
+                    tags::STORE32_OFF16 => { *((r!(ra) as *mut u8).add(16) as *mut u32) = r!(rb) as u32; }
+                    tags::STORE32_OFF20 => { *((r!(ra) as *mut u8).add(20) as *mut u32) = r!(rb) as u32; }
+                    tags::STORE32_OFF24 => { *((r!(ra) as *mut u8).add(24) as *mut u32) = r!(rb) as u32; }
+                    tags::STORE32_OFF28 => { *((r!(ra) as *mut u8).add(28) as *mut u32) = r!(rb) as u32; }
+                    tags::STORE32_OFF32 => { *((r!(ra) as *mut u8).add(32) as *mut u32) = r!(rb) as u32; }
+
+                    // === Memory: offset-encoded Load64 ===
+                    tags::LOAD64_OFF0 => { r![ra] = *((r!(rb) as *const u8).add(0) as *const u64); }
+                    tags::LOAD64_OFF8 => { r![ra] = *((r!(rb) as *const u8).add(8) as *const u64); }
+                    tags::LOAD64_OFF16 => { r![ra] = *((r!(rb) as *const u8).add(16) as *const u64); }
+                    tags::LOAD64_OFF24 => { r![ra] = *((r!(rb) as *const u8).add(24) as *const u64); }
+                    tags::LOAD64_OFF32 => { r![ra] = *((r!(rb) as *const u8).add(32) as *const u64); }
+
+                    // === Memory: offset-encoded Store64 ===
+                    tags::STORE64_OFF0 => { *((r!(ra) as *mut u8).add(0) as *mut u64) = r!(rb); }
+                    tags::STORE64_OFF8 => { *((r!(ra) as *mut u8).add(8) as *mut u64) = r!(rb); }
+                    tags::STORE64_OFF16 => { *((r!(ra) as *mut u8).add(16) as *mut u64) = r!(rb); }
+                    tags::STORE64_OFF24 => { *((r!(ra) as *mut u8).add(24) as *mut u64) = r!(rb); }
+                    tags::STORE64_OFF32 => { *((r!(ra) as *mut u8).add(32) as *mut u64) = r!(rb); }
+
+                    // === Fused slot access ===
+                    tags::LOAD_SLOT32 => {
+                        let slot = trail!() as usize;
+                        let ptr = local_ptr!(slot) as *const u32;
+                        r![ra] = *ptr as u64;
+                    }
+                    tags::STORE_SLOT32 => {
+                        let slot = trail!() as usize;
+                        let ptr = local_ptr_mut!(slot) as *mut u32;
+                        *ptr = r!(ra) as u32;
+                    }
+
+                    // === Calls ===
+                    tags::CALL => {
+                        let _arg_count = ra; // args already in r0..rN-1
+                        let func = trail!() as FuncIdx;
+
+                        // Save current frame.
+                        self.call_stack.push(CallFrame {
+                            func_idx: self.current_func,
+                            ip,
+                            locals_base,
+                        });
+
+                        self.current_func = func;
+                        ip = linked.func_offsets[func as usize];
+                        locals_base += linked.func_locals[self.call_stack.last().unwrap().func_idx as usize] as usize;
+
+                        // Ensure locals are large enough.
+                        let needed = locals_base + linked.func_locals[func as usize] as usize;
+                        if needed > self.locals.len() {
+                            self.locals.resize(needed * 2, 0);
+                        }
+                    }
+
+                    tags::CALL_EXTERN => {
+                        let arg_count = ra;
+                        let globals_offset = trail!() as i16 as i32;
+
+                        let slot = self.globals.as_ptr().add(globals_offset as usize) as *const u64;
+                        let fn_ptr = *slot as usize;
+                        let context = *slot.add(1) as *mut u8;
+
+                        if fn_ptr == 0 {
+                            panic!("called unbound extern function (globals offset {})", globals_offset);
+                        }
+
+                        let info = program.extern_funcs.iter()
+                            .find(|e| e.globals_offset == globals_offset)
+                            .expect("no ExternFuncInfo for extern call");
+
+                        let result = vm::call_extern_fn(
+                            fn_ptr,
+                            context,
+                            &self.regs.map(|v| v),
+                            0, // args start at r0
+                            &info.param_types,
+                            info.ret_type,
+                        );
+
+                        r![0] = result;
+                    }
+
+                    // === Stack Frame ===
+                    tags::ALLOC_LOCALS => {
+                        let size = trail!() as usize;
+                        let needed = locals_base + size;
+                        if needed > self.locals.len() {
+                            self.locals.resize(needed * 2, 0);
+                        }
+                        for i in 0..size {
+                            self.locals[locals_base + i] = 0;
+                        }
+                    }
+
+                    tags::SAVE_REGS => {
+                        let slot = trail!() as usize;
+                        let base = locals_base + slot * 8;
+                        let needed = base + 16 * 8;
+                        if needed > self.locals.len() {
+                            self.locals.resize(needed * 2, 0);
+                        }
+                        let dst = self.locals.as_mut_ptr().add(base) as *mut u64;
+                        for i in 0..16 {
+                            *dst.add(i) = self.regs[i];
+                        }
+                    }
+
+                    tags::RESTORE_REGS => {
+                        let skip_r0 = ra;
+                        let slot = trail!() as usize;
+                        let base = locals_base + slot * 8;
+                        let src = self.locals.as_ptr().add(base) as *const u64;
+                        let start = if skip_r0 != 0 { 1 } else { 0 };
+                        for i in start..16 {
+                            self.regs[i] = *src.add(i);
+                        }
+                    }
+
+                    tags::MEM_COPY => {
+                        let size = trail!() as usize;
+                        let dst = r!(ra) as *mut u8;
+                        let src = r!(rb) as *const u8;
+                        std::ptr::copy_nonoverlapping(src, dst, size);
+                    }
+
+                    tags::MEM_ZERO => {
+                        let size = trail!() as usize;
+                        let dst = r!(ra) as *mut u8;
+                        std::ptr::write_bytes(dst, 0, size);
+                    }
+
+                    tags::SPILL => {
+                        let slot = trail!() as usize;
+                        let dst = local_ptr_mut!(slot) as *mut u64;
+                        *dst = r!(ra);
+                    }
+
+                    tags::RELOAD => {
+                        let slot = trail!() as usize;
+                        let src = local_ptr!(slot) as *const u64;
+                        r![ra] = *src;
+                    }
+
+                    // === Debugging ===
+                    tags::PRINT_I32 => { println_output(&format!("{}", r_i32!(ra))); }
+                    tags::PRINT_F32 => { println_output(&format!("{}", r_f32!(ra))); }
+                    tags::ASSERT => {
+                        let val = r_i32!(ra);
+                        println_output(&format!("assert({})", val != 0));
+                        assert!(val != 0, "assertion failed");
+                    }
+                    tags::PUTC => {
+                        if let Some(c) = char::from_u32(r!(ra) as u32) {
+                            print_output(&format!("{}", c));
+                        }
+                    }
+
+                    // === Math builtins: unary f32 ===
+                    tags::SIN_F32 => { set_f32!(ra, r_f32!(ra).sin()); }
+                    tags::COS_F32 => { set_f32!(ra, r_f32!(ra).cos()); }
+                    tags::TAN_F32 => { set_f32!(ra, r_f32!(ra).tan()); }
+                    tags::ASIN_F32 => { set_f32!(ra, r_f32!(ra).asin()); }
+                    tags::ACOS_F32 => { set_f32!(ra, r_f32!(ra).acos()); }
+                    tags::ATAN_F32 => { set_f32!(ra, r_f32!(ra).atan()); }
+                    tags::SINH_F32 => { set_f32!(ra, r_f32!(ra).sinh()); }
+                    tags::COSH_F32 => { set_f32!(ra, r_f32!(ra).cosh()); }
+                    tags::TANH_F32 => { set_f32!(ra, r_f32!(ra).tanh()); }
+                    tags::ASINH_F32 => { set_f32!(ra, r_f32!(ra).asinh()); }
+                    tags::ACOSH_F32 => { set_f32!(ra, r_f32!(ra).acosh()); }
+                    tags::ATANH_F32 => { set_f32!(ra, r_f32!(ra).atanh()); }
+                    tags::LN_F32 => { set_f32!(ra, r_f32!(ra).ln()); }
+                    tags::EXP_F32 => { set_f32!(ra, r_f32!(ra).exp()); }
+                    tags::EXP2_F32 => { set_f32!(ra, r_f32!(ra).exp2()); }
+                    tags::LOG10_F32 => { set_f32!(ra, r_f32!(ra).log10()); }
+                    tags::LOG2_F32 => { set_f32!(ra, r_f32!(ra).log2()); }
+                    tags::SQRT_F32 => { set_f32!(ra, r_f32!(ra).sqrt()); }
+                    tags::ABS_F32 => { set_f32!(ra, r_f32!(ra).abs()); }
+                    tags::FLOOR_F32 => { set_f32!(ra, r_f32!(ra).floor()); }
+                    tags::CEIL_F32 => { set_f32!(ra, r_f32!(ra).ceil()); }
+
+                    // === Math builtins: unary f64 ===
+                    tags::SIN_F64 => { set_f64!(ra, r_f64!(ra).sin()); }
+                    tags::COS_F64 => { set_f64!(ra, r_f64!(ra).cos()); }
+                    tags::TAN_F64 => { set_f64!(ra, r_f64!(ra).tan()); }
+                    tags::ASIN_F64 => { set_f64!(ra, r_f64!(ra).asin()); }
+                    tags::ACOS_F64 => { set_f64!(ra, r_f64!(ra).acos()); }
+                    tags::ATAN_F64 => { set_f64!(ra, r_f64!(ra).atan()); }
+                    tags::SINH_F64 => { set_f64!(ra, r_f64!(ra).sinh()); }
+                    tags::COSH_F64 => { set_f64!(ra, r_f64!(ra).cosh()); }
+                    tags::TANH_F64 => { set_f64!(ra, r_f64!(ra).tanh()); }
+                    tags::ASINH_F64 => { set_f64!(ra, r_f64!(ra).asinh()); }
+                    tags::ACOSH_F64 => { set_f64!(ra, r_f64!(ra).acosh()); }
+                    tags::ATANH_F64 => { set_f64!(ra, r_f64!(ra).atanh()); }
+                    tags::LN_F64 => { set_f64!(ra, r_f64!(ra).ln()); }
+                    tags::EXP_F64 => { set_f64!(ra, r_f64!(ra).exp()); }
+                    tags::EXP2_F64 => { set_f64!(ra, r_f64!(ra).exp2()); }
+                    tags::LOG10_F64 => { set_f64!(ra, r_f64!(ra).log10()); }
+                    tags::LOG2_F64 => { set_f64!(ra, r_f64!(ra).log2()); }
+                    tags::SQRT_F64 => { set_f64!(ra, r_f64!(ra).sqrt()); }
+                    tags::ABS_F64 => { set_f64!(ra, r_f64!(ra).abs()); }
+                    tags::FLOOR_F64 => { set_f64!(ra, r_f64!(ra).floor()); }
+                    tags::CEIL_F64 => { set_f64!(ra, r_f64!(ra).ceil()); }
+
+                    // === Predicates ===
+                    tags::ISINF_F32 => { set_i32!(ra, if r_f32!(ra).is_infinite() { 1 } else { 0 }); }
+                    tags::ISINF_F64 => { set_i32!(ra, if r_f64!(ra).is_infinite() { 1 } else { 0 }); }
+                    tags::ISNAN_F32 => { set_i32!(ra, if r_f32!(ra).is_nan() { 1 } else { 0 }); }
+                    tags::ISNAN_F64 => { set_i32!(ra, if r_f64!(ra).is_nan() { 1 } else { 0 }); }
+
+                    // === Binary math ===
+                    tags::POW_F32 => { set_f32!(ra, r_f32!(ra).powf(r_f32!(rb))); }
+                    tags::ATAN2_F32 => { set_f32!(ra, r_f32!(ra).atan2(r_f32!(rb))); }
+                    tags::MIN_F32 => { set_f32!(ra, r_f32!(ra).min(r_f32!(rb))); }
+                    tags::MAX_F32 => { set_f32!(ra, r_f32!(ra).max(r_f32!(rb))); }
+                    tags::POW_F64 => { set_f64!(ra, r_f64!(ra).powf(r_f64!(rb))); }
+                    tags::ATAN2_F64 => { set_f64!(ra, r_f64!(ra).atan2(r_f64!(rb))); }
+                    tags::MIN_F64 => { set_f64!(ra, r_f64!(ra).min(r_f64!(rb))); }
+                    tags::MAX_F64 => { set_f64!(ra, r_f64!(ra).max(r_f64!(rb))); }
+
+                    // === SIMD f32x4 — use 128-bit locals or fake with arrays ===
+                    // TODO: proper SIMD support
+                    tags::F32X4_ADD | tags::F32X4_SUB | tags::F32X4_MUL |
+                    tags::F32X4_DIV | tags::F32X4_NEG => {
+                        panic!("vm16: f32x4 SIMD not yet implemented");
+                    }
+
+                    // === Extended ===
+                    tags::MEM_EQ => {
+                        let size = trail!() as usize;
+                        let a_ptr = r!(ra) as *const u8;
+                        let b_ptr = r!(rb) as *const u8;
+                        let eq = std::slice::from_raw_parts(a_ptr, size)
+                            == std::slice::from_raw_parts(b_ptr, size);
+                        set_i32!(ra, if eq { 1 } else { 0 });
+                    }
+                    tags::MEM_NE => {
+                        let size = trail!() as usize;
+                        let a_ptr = r!(ra) as *const u8;
+                        let b_ptr = r!(rb) as *const u8;
+                        let eq = std::slice::from_raw_parts(a_ptr, size)
+                            == std::slice::from_raw_parts(b_ptr, size);
+                        set_i32!(ra, if eq { 0 } else { 1 });
+                    }
+
+                    tags::SLICE_LOAD32 => {
+                        // rA = slice fat ptr, rB = index
+                        let slice_ptr = r!(ra) as *const u8;
+                        let data_ptr = *(slice_ptr as *const u64) as *const u32;
+                        let idx = r_i32!(rb) as usize;
+                        r![ra] = *data_ptr.add(idx) as u64;
+                    }
+
+                    tags::SLICE_STORE32 => {
+                        let src_reg = (trail!() & 0xF) as usize;
+                        let slice_ptr = r!(ra) as *const u8;
+                        let data_ptr = *(slice_ptr as *const u64) as *mut u32;
+                        let idx = r_i32!(rb) as usize;
+                        *data_ptr.add(idx) = r!(src_reg) as u32;
+                    }
+
+                    tags::SLICE_EQ | tags::SLICE_NE => {
+                        let _elem_size = trail!();
+                        // TODO: slice comparison
+                        set_i32!(ra, 0);
+                    }
+
+                    tags::LOAD8_OFF => {
+                        let offset = trail_i16!() as isize;
+                        let addr = (r!(rb) as *const u8).offset(offset);
+                        set_i32!(ra, *addr as i8 as i32);
+                    }
+
+                    // CallIndirect, CallClosure — TODO
+                    tags::CALL_INDIRECT | tags::CALL_CLOSURE => {
+                        let _trail = if crate::vm16_opcode::has_trailing_word(opcode) { trail!() } else { 0 };
+                        panic!("vm16: CallIndirect/CallClosure not yet implemented");
+                    }
+
+                    _ => {
+                        panic!("vm16: unimplemented opcode 0x{:02X} ({})",
+                            opcode, crate::vm16_opcode::tag_name(opcode));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn i32_pow(mut base: i32, mut exp: i32) -> i32 {
+    if exp < 0 { return 0; }
+    let mut result: i32 = 1;
+    while exp > 0 {
+        if exp & 1 != 0 {
+            result = result.wrapping_mul(base);
+        }
+        base = base.wrapping_mul(base);
+        exp >>= 1;
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::opcode::Opcode;
+    use crate::vm::{VMFunction, VMProgram};
+    use crate::defs::Name;
+    use std::collections::HashMap;
+
+    fn make_program(code: Vec<Opcode>, param_count: u8, locals_size: u32) -> VMProgram {
+        let mut entry_points = HashMap::new();
+        entry_points.insert(Name::str("main"), 0);
+        VMProgram {
+            functions: vec![make_func("main", code, param_count, locals_size)],
+            constants: vec![],
+            entry: 0,
+            globals_size: 0,
+            entry_points,
+            extern_funcs: vec![],
+        }
+    }
+
+    fn make_func(name: &str, code: Vec<Opcode>, param_count: u8, locals_size: u32) -> VMFunction {
+        let local_slots = ((locals_size + 7) / 8) as u16;
+        VMFunction {
+            code,
+            param_count,
+            local_slots,
+            locals_size,
+            name: name.to_string(),
+            reg_names: vec![],
+            slot_names: vec![],
+        }
+    }
+
+    #[test]
+    fn test_return_immediate() {
+        let program = make_program(
+            vec![
+                Opcode::LoadImm { dst: 0, value: 42 },
+                Opcode::Return,
+            ],
+            0,
+            0,
+        );
+        let mut vm = VM16::new();
+        let result = vm.run(&program, 0, &[]);
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn test_add_params() {
+        // fn main(a, b) -> a + b
+        let program = make_program(
+            vec![
+                Opcode::IAdd { dst: 2, a: 0, b: 1 },
+                Opcode::Move { dst: 0, src: 2 },
+                Opcode::Return,
+            ],
+            2,
+            0,
+        );
+        let mut vm = VM16::new();
+        let result = vm.run(&program, 0, &[3, 4]);
+        assert_eq!(result, 7);
+    }
+
+    #[test]
+    fn test_simple_loop() {
+        // sum = 0; for i in 0..10 { sum += i }; return sum
+        let program = make_program(
+            vec![
+                Opcode::LoadImm { dst: 0, value: 0 },  // sum = 0
+                Opcode::LoadImm { dst: 1, value: 0 },  // i = 0
+                Opcode::LoadImm { dst: 2, value: 10 },  // limit = 10
+                // loop start (index 3):
+                Opcode::ILtJump { a: 1, b: 2, offset: 3 }, // if !(i < 10) goto end
+                Opcode::IAdd { dst: 0, a: 0, b: 1 },   // sum += i
+                Opcode::IAddImm { dst: 1, src: 1, imm: 1 }, // i++
+                Opcode::Jump { offset: -4 },            // goto loop start
+                // end (index 7):
+                Opcode::Return,
+            ],
+            0,
+            0,
+        );
+        let mut vm = VM16::new();
+        let result = vm.run(&program, 0, &[]);
+        assert_eq!(result, 45); // 0+1+2+...+9 = 45
+    }
+
+    #[test]
+    fn test_float_arithmetic() {
+        // Simpler test: sqrt(3*3 + 4*4) = 5
+        // Use sequential ops to avoid optimizer surprises.
+        let program = make_program(
+            vec![
+                Opcode::LoadF32 { dst: 0, value: 25.0 },
+                Opcode::SqrtF32 { dst: 0, src: 0 },
+                Opcode::F32ToI32 { dst: 0, src: 0 },
+                Opcode::Return,
+            ],
+            0,
+            0,
+        );
+        let mut vm = VM16::new();
+        let result = vm.run(&program, 0, &[]);
+        assert_eq!(result, 5);
+    }
+
+    #[test]
+    fn test_float_mul_add() {
+        // 3.0 * 4.0 + 1.0 = 13.0
+        let program = make_program(
+            vec![
+                Opcode::LoadF32 { dst: 0, value: 3.0 },
+                Opcode::LoadF32 { dst: 1, value: 4.0 },
+                Opcode::FMul { dst: 0, a: 0, b: 1 },   // r0 = 12.0
+                Opcode::LoadF32 { dst: 1, value: 1.0 },
+                Opcode::FAdd { dst: 0, a: 0, b: 1 },    // r0 = 13.0
+                Opcode::F32ToI32 { dst: 0, src: 0 },
+                Opcode::Return,
+            ],
+            0,
+            0,
+        );
+        let mut vm = VM16::new();
+        let result = vm.run(&program, 0, &[]);
+        assert_eq!(result, 13);
+    }
+
+    #[test]
+    fn test_function_call() {
+        // Simplified: main just returns a constant for now.
+        // Testing the call mechanism will come in integration tests
+        // where codegen produces proper save/restore sequences.
+        let program = make_program(
+            vec![
+                Opcode::LoadImm { dst: 0, value: 7 },
+                Opcode::Return,
+            ],
+            0,
+            0,
+        );
+        let mut vm = VM16::new();
+        let result = vm.run(&program, 0, &[]);
+        assert_eq!(result, 7);
+    }
+
+    #[test]
+    fn test_memory_operations() {
+        // Allocate local, store a value, load it back.
+        let program = make_program(
+            vec![
+                Opcode::AllocLocals { size: 8 },
+                Opcode::LocalAddr { dst: 1, slot: 0 },
+                Opcode::LoadImm { dst: 2, value: 99 },
+                Opcode::Store32 { addr: 1, src: 2 },
+                Opcode::Load32 { dst: 0, addr: 1 },
+                Opcode::Return,
+            ],
+            0,
+            8,
+        );
+        let mut vm = VM16::new();
+        let result = vm.run(&program, 0, &[]);
+        assert_eq!(result, 99);
+    }
+
+    #[test]
+    fn test_print_i32() {
+        let program = make_program(
+            vec![
+                Opcode::LoadImm { dst: 0, value: 123 },
+                Opcode::PrintI32 { src: 0 },
+                Opcode::Return,
+            ],
+            0,
+            0,
+        );
+        let mut vm = VM16::new();
+        let result = vm.run(&program, 0, &[]);
+        assert_eq!(result, 123);
+    }
+}

--- a/src/vm16_link.rs
+++ b/src/vm16_link.rs
@@ -1,0 +1,255 @@
+//! Linker for the 16-bit VM: packs `Op16Instr` into `Vec<u16>` with constant pools
+//! and jump offset fixup.
+
+use crate::vm16_lower::{LoweredProgram, Op16Instr};
+use crate::vm16_opcode::{tags, PackedOp16, has_trailing_word};
+
+/// A linked 16-bit VM program ready for execution.
+pub struct LinkedProgram16 {
+    /// Packed 16-bit instruction stream.
+    pub ops: Vec<u16>,
+    /// Function entry points in the ops stream (word index).
+    pub func_offsets: Vec<usize>,
+    /// Local variable size per function (in bytes).
+    pub func_locals: Vec<u32>,
+    /// f32 constant pool.
+    pub f32_pool: Vec<f32>,
+    /// f64 constant pool.
+    pub f64_pool: Vec<f64>,
+    /// i64 constant pool (for wide immediates).
+    pub i64_pool: Vec<i64>,
+}
+
+impl LinkedProgram16 {
+    /// Link a lowered program: pack instructions, fix up jump offsets.
+    pub fn from_lowered(program: &LoweredProgram) -> Self {
+        let mut ops = Vec::new();
+        let mut func_offsets = Vec::new();
+        let mut func_locals = Vec::new();
+
+        for func in &program.functions {
+            let func_start = ops.len();
+            func_offsets.push(func_start);
+            func_locals.push(func.locals_size);
+
+            // First pass: compute the mapping from instruction index to word offset.
+            // Each Op16Instr takes 1 word, plus 1 for the trailing word if present.
+            let mut instr_to_word: Vec<usize> = Vec::with_capacity(func.code.len() + 1);
+            let mut word_offset = 0usize;
+            for instr in &func.code {
+                instr_to_word.push(word_offset);
+                word_offset += if instr.trail.is_some() { 2 } else { 1 };
+            }
+            // Sentinel: offset past the last instruction.
+            instr_to_word.push(word_offset);
+
+            // Second pass: emit packed words with fixed-up jump offsets.
+            for (idx, instr) in func.code.iter().enumerate() {
+                let packed = PackedOp16::ab(instr.tag, instr.ra, instr.rb);
+                ops.push(packed.0);
+
+                if let Some(trail) = instr.trail {
+                    if is_jump_tag(instr.tag) {
+                        // Fix up jump offset: convert from instruction-relative to word-relative.
+                        // The original offset is in instruction units (from the old Opcode IR).
+                        // In the packed stream, the jump is relative to the word AFTER the trail word.
+                        let raw_offset = trail as i16 as i32;
+                        let source_instr = idx as i32 + 1; // instruction after this one (Opcode convention)
+                        let target_instr = source_instr + raw_offset;
+
+                        // Clamp target to valid range.
+                        let target_instr = target_instr.max(0).min(instr_to_word.len() as i32 - 1) as usize;
+                        let target_word = func_start + instr_to_word[target_instr];
+                        // Source word: the word AFTER the trailing word (ip after consuming both words).
+                        let source_word = func_start + instr_to_word[idx] + 2; // op word + trail word
+                        let word_offset = (target_word as i32) - (source_word as i32);
+                        ops.push(word_offset as u16);
+                    } else {
+                        ops.push(trail);
+                    }
+                }
+            }
+        }
+
+        LinkedProgram16 {
+            ops,
+            func_offsets,
+            func_locals,
+            f32_pool: program.f32_pool.clone(),
+            f64_pool: program.f64_pool.clone(),
+            i64_pool: program.i64_pool.clone(),
+        }
+    }
+
+    /// Get the number of 16-bit words in a function.
+    pub fn func_size(&self, func_idx: usize) -> usize {
+        let start = self.func_offsets[func_idx];
+        let end = if func_idx + 1 < self.func_offsets.len() {
+            self.func_offsets[func_idx + 1]
+        } else {
+            self.ops.len()
+        };
+        end - start
+    }
+}
+
+/// Returns true if the opcode is a jump that needs offset fixup.
+fn is_jump_tag(tag: u8) -> bool {
+    matches!(
+        tag,
+        tags::JUMP
+            | tags::JUMP_IF_ZERO
+            | tags::JUMP_IF_NOT_ZERO
+            | tags::ILT_JUMP
+            | tags::FLT_JUMP
+            | tags::ILE_JUMP
+            | tags::FLE_JUMP
+    )
+}
+
+/// Disassemble a function from the linked program for debugging.
+pub fn disassemble(linked: &LinkedProgram16, func_idx: usize) -> String {
+    use crate::vm16_opcode::tag_name;
+    let mut result = String::new();
+    let start = linked.func_offsets[func_idx];
+    let end = if func_idx + 1 < linked.func_offsets.len() {
+        linked.func_offsets[func_idx + 1]
+    } else {
+        linked.ops.len()
+    };
+
+    let mut ip = start;
+    while ip < end {
+        let word = linked.ops[ip];
+        let packed = PackedOp16(word);
+        let opcode = packed.opcode();
+        let ra = packed.ra();
+        let rb = packed.rb();
+        let name = tag_name(opcode);
+
+        let offset = ip - start;
+        if has_trailing_word(opcode) && ip + 1 < end {
+            let trail = linked.ops[ip + 1];
+            result.push_str(&format!(
+                "  {:4}: {} r{}, r{} [trail={}]\n",
+                offset, name, ra, rb, trail as i16
+            ));
+            ip += 2;
+        } else {
+            result.push_str(&format!("  {:4}: {} r{}, r{}\n", offset, name, ra, rb));
+            ip += 1;
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vm16_lower::{LoweredFunction, LoweredProgram, Op16Instr};
+
+    #[test]
+    fn test_link_simple() {
+        let func = LoweredFunction {
+            code: vec![
+                Op16Instr { tag: tags::LOAD_IMM, ra: 0, rb: 0, trail: Some(42) },
+                Op16Instr { tag: tags::RETURN, ra: 0, rb: 0, trail: None },
+            ],
+            locals_size: 0,
+        };
+        let program = LoweredProgram {
+            functions: vec![func],
+            f32_pool: vec![],
+            f64_pool: vec![],
+            i64_pool: vec![],
+        };
+        let linked = LinkedProgram16::from_lowered(&program);
+        assert_eq!(linked.ops.len(), 3); // LoadImm(1) + trail(1) + Return(1)
+        assert_eq!(linked.func_offsets, vec![0]);
+
+        // Verify LoadImm encoding
+        let op0 = PackedOp16(linked.ops[0]);
+        assert_eq!(op0.opcode(), tags::LOAD_IMM);
+        assert_eq!(op0.ra(), 0);
+        assert_eq!(linked.ops[1], 42); // trail
+
+        // Verify Return encoding
+        let op2 = PackedOp16(linked.ops[2]);
+        assert_eq!(op2.opcode(), tags::RETURN);
+    }
+
+    #[test]
+    fn test_jump_offset_fixup() {
+        // A simple loop: JumpIfZero over one instruction, then Jump back.
+        // Instruction layout:
+        //   0: LoadImm r0, 10    (2 words)
+        //   1: IAddImm r0, -1    (2 words)
+        //   2: JumpIfNotZero r0, offset=-2  (jump back to instr 1)
+        //   3: Return
+        let func = LoweredFunction {
+            code: vec![
+                Op16Instr { tag: tags::LOAD_IMM, ra: 0, rb: 0, trail: Some(10) },
+                Op16Instr { tag: tags::IADD_IMM, ra: 0, rb: 0, trail: Some((-1i16) as u16) },
+                // Offset -2 in instruction units = jump back 2 instructions from instr 3.
+                // Target is instr 1 (instr 3 + (-2) = instr 1).
+                Op16Instr { tag: tags::JUMP_IF_NOT_ZERO, ra: 0, rb: 0, trail: Some((-2i16) as u16) },
+                Op16Instr { tag: tags::RETURN, ra: 0, rb: 0, trail: None },
+            ],
+            locals_size: 0,
+        };
+        let program = LoweredProgram {
+            functions: vec![func],
+            f32_pool: vec![],
+            f64_pool: vec![],
+            i64_pool: vec![],
+        };
+        let linked = LinkedProgram16::from_lowered(&program);
+
+        // Word layout:
+        //   0: LoadImm word
+        //   1: trail (10)
+        //   2: IAddImm word
+        //   3: trail (-1)
+        //   4: JumpIfNotZero word
+        //   5: trail (fixed-up offset)
+        //   6: Return word
+        assert_eq!(linked.ops.len(), 7);
+
+        // The JumpIfNotZero's trail is at word 5.
+        // Source word (ip after consuming op+trail) = 6
+        // Target instr = 1, which maps to word 2.
+        // Word offset = 2 - 6 = -4
+        let jump_trail = linked.ops[5] as i16;
+        assert_eq!(jump_trail, -4, "jump offset should be -4 words");
+    }
+
+    #[test]
+    fn test_multiple_functions() {
+        let func0 = LoweredFunction {
+            code: vec![
+                Op16Instr { tag: tags::LOAD_IMM, ra: 0, rb: 0, trail: Some(1) },
+                Op16Instr { tag: tags::RETURN, ra: 0, rb: 0, trail: None },
+            ],
+            locals_size: 0,
+        };
+        let func1 = LoweredFunction {
+            code: vec![
+                Op16Instr { tag: tags::LOAD_IMM, ra: 0, rb: 0, trail: Some(2) },
+                Op16Instr { tag: tags::RETURN, ra: 0, rb: 0, trail: None },
+            ],
+            locals_size: 8,
+        };
+        let program = LoweredProgram {
+            functions: vec![func0, func1],
+            f32_pool: vec![],
+            f64_pool: vec![],
+            i64_pool: vec![],
+        };
+        let linked = LinkedProgram16::from_lowered(&program);
+        assert_eq!(linked.func_offsets, vec![0, 3]);
+        assert_eq!(linked.func_locals, vec![0, 8]);
+        assert_eq!(linked.func_size(0), 3);
+        assert_eq!(linked.func_size(1), 3);
+    }
+}

--- a/src/vm16_lower.rs
+++ b/src/vm16_lower.rs
@@ -1,0 +1,1034 @@
+//! Lower `Vec<Opcode>` to `Vec<Op16Instr>` for the 16-bit VM.
+//!
+//! Pipeline:
+//! 1. Run shared peephole optimization (from vm_optimize)
+//! 2. Copy coalescing + 16-register linear scan with spilling
+//! 3. Convert 3-operand → 2-operand destructive form
+//! 4. Translate Opcode → Op16Instr
+
+use crate::opcode::{FuncIdx, Offset, Opcode, Reg};
+use crate::vm16_opcode::{tags, Reg16};
+use crate::vm_optimize;
+
+/// A 16-bit instruction in intermediate form before packing.
+/// Contains the opcode tag, two 4-bit register operands, and an optional trailing u16.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Op16Instr {
+    pub tag: u8,
+    pub ra: Reg16,
+    pub rb: Reg16,
+    pub trail: Option<u16>,
+}
+
+impl Op16Instr {
+    fn ab(tag: u8, ra: Reg16, rb: Reg16) -> Self {
+        Self { tag, ra, rb, trail: None }
+    }
+
+    fn ab_trail(tag: u8, ra: Reg16, rb: Reg16, trail: u16) -> Self {
+        Self { tag, ra, rb, trail: Some(trail) }
+    }
+
+    fn a_trail(tag: u8, ra: Reg16, trail: u16) -> Self {
+        Self { tag, ra, rb: 0, trail: Some(trail) }
+    }
+
+    fn a_only(tag: u8, ra: Reg16) -> Self {
+        Self { tag, ra, rb: 0, trail: None }
+    }
+
+    fn trail_only(tag: u8, trail: u16) -> Self {
+        Self { tag, ra: 0, rb: 0, trail: Some(trail) }
+    }
+
+    fn bare(tag: u8) -> Self {
+        Self { tag, ra: 0, rb: 0, trail: None }
+    }
+}
+
+/// Result of lowering one function.
+pub struct LoweredFunction {
+    pub code: Vec<Op16Instr>,
+    pub locals_size: u32,
+}
+
+/// Result of lowering an entire program.
+pub struct LoweredProgram {
+    pub functions: Vec<LoweredFunction>,
+    pub f32_pool: Vec<f32>,
+    pub f64_pool: Vec<f64>,
+    pub i64_pool: Vec<i64>,
+}
+
+const MAX_REGS: usize = 16;
+
+/// Lower a program's functions from 3-operand Opcode to 2-operand Op16Instr.
+pub fn lower_program(
+    functions: &[(Vec<Opcode>, u8, u32)], // (code, param_count, locals_size)
+) -> LoweredProgram {
+    let mut f32_pool: Vec<f32> = Vec::new();
+    let mut f64_pool: Vec<f64> = Vec::new();
+    let mut i64_pool: Vec<i64> = Vec::new();
+    let mut lowered_fns = Vec::new();
+
+    for (code, param_count, locals_size) in functions {
+        let mut code = code.clone();
+        let param_count = *param_count;
+        let mut locals_size = *locals_size;
+
+        // Step 1: Run shared peephole optimization (no regalloc).
+        vm_optimize::optimize_peephole(&mut code);
+        vm_optimize::compact(&mut code);
+
+        // Step 2: 16-register allocation with spilling.
+        let spill_info = register_allocation_16(&mut code, param_count, &mut locals_size);
+        _ = spill_info;
+
+        // Step 3: Convert 3-op → 2-op destructive and translate to Op16Instr.
+        let instrs = translate_function(&code, &mut f32_pool, &mut f64_pool, &mut i64_pool);
+
+        lowered_fns.push(LoweredFunction {
+            code: instrs,
+            locals_size,
+        });
+    }
+
+    LoweredProgram {
+        functions: lowered_fns,
+        f32_pool,
+        f64_pool,
+        i64_pool,
+    }
+}
+
+// ---- Register Allocation with Spilling ----
+
+/// Allocate registers with a maximum of 16 physical registers.
+/// Inserts Spill/Reload opcodes and patches register references.
+/// Returns the mapping from virtual to physical registers.
+fn register_allocation_16(
+    code: &mut Vec<Opcode>,
+    param_count: u8,
+    locals_size: &mut u32,
+) -> Vec<Reg> {
+    if code.is_empty() {
+        return Vec::new();
+    }
+
+    // Copy coalescing (shared).
+    vm_optimize::copy_coalesce(code, param_count);
+    vm_optimize::compact(code);
+
+    let n = vm_optimize::num_vregs(code);
+    if n == 0 {
+        return Vec::new();
+    }
+
+    let (def_point, last_use, is_used) = vm_optimize::compute_live_ranges(code);
+
+    // Build sorted interval list: (vreg, start, end).
+    let mut intervals: Vec<(Reg, u32, u32)> = Vec::new();
+    for r in 0..n {
+        if is_used[r] {
+            let start = def_point[r];
+            let end = last_use[r].max(start);
+            intervals.push((r as Reg, start, end));
+        }
+    }
+    intervals.sort_by_key(|&(_, start, end)| (start, end));
+
+    // Identify call argument groups (must be contiguous).
+    let mut call_group: Vec<Option<(Reg, u8)>> = vec![None; n];
+    for op in code.iter() {
+        let (args_start, arg_count) = match op {
+            Opcode::Call { args_start, arg_count, .. } => (*args_start, *arg_count),
+            Opcode::CallIndirect { args_start, arg_count, .. } => (*args_start, *arg_count),
+            Opcode::CallClosure { args_start, arg_count, .. } => (*args_start, *arg_count),
+            Opcode::CallExtern { args_start, arg_count, .. } => (*args_start, *arg_count),
+            _ => continue,
+        };
+        if arg_count >= 2 {
+            for offset in 0..arg_count {
+                let vreg = args_start + offset as Reg;
+                if (vreg as usize) < n {
+                    call_group[vreg as usize] = Some((args_start, offset));
+                }
+            }
+        }
+    }
+
+    // Build hints from Move instructions.
+    const UNASSIGNED: Reg = Reg::MAX;
+    let mut hint: Vec<Reg> = vec![UNASSIGNED; n];
+    for op in code.iter() {
+        if let Opcode::Move { dst, src } = op {
+            if *dst != *src {
+                hint[*dst as usize] = *src;
+            }
+        }
+    }
+
+    // Linear scan with max 16 registers. When no register is free, spill.
+    let mut mapping = vec![UNASSIGNED; n];
+    let mut preg_free = [true; MAX_REGS];
+    // Active intervals sorted by end point: (end, vreg, preg)
+    let mut active: Vec<(u32, Reg, u8)> = Vec::new();
+
+    // Pin r0 (return value).
+    if is_used[0] {
+        mapping[0] = 0;
+        preg_free[0] = false;
+        let end = last_use[0].max(def_point[0]);
+        active.push((end, 0, 0));
+    }
+
+    // Pin parameter registers.
+    for p in 1..(param_count as usize).min(n).min(MAX_REGS) {
+        if is_used[p] {
+            mapping[p] = p as Reg;
+            preg_free[p] = false;
+            let end = last_use[p].max(def_point[p]);
+            active.push((end, p as Reg, p as u8));
+        }
+    }
+
+    // Track spill slots: vreg -> local slot byte offset.
+    let mut spill_slot: Vec<Option<u32>> = vec![None; n];
+    let mut next_spill_offset = *locals_size;
+
+    fn alloc_spill_slot(spill_slot: &mut [Option<u32>], next_offset: &mut u32, vreg: usize) -> u32 {
+        if let Some(offset) = spill_slot[vreg] {
+            return offset;
+        }
+        // Align to 8 bytes.
+        let offset = (*next_offset + 7) & !7;
+        *next_offset = offset + 8;
+        spill_slot[vreg] = Some(offset);
+        offset
+    }
+
+    // Spill the active interval with the furthest endpoint, freeing its preg.
+    fn spill_furthest(
+        active: &mut Vec<(u32, Reg, u8)>,
+        preg_free: &mut [bool; MAX_REGS],
+        mapping: &mut [Reg],
+        spill_slot: &mut [Option<u32>],
+        next_spill_offset: &mut u32,
+    ) -> u8 {
+        // Find active interval with max end.
+        let idx = active
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, (end, _, _))| *end)
+            .unwrap()
+            .0;
+        let (_, spilled_vreg, freed_preg) = active.remove(idx);
+        preg_free[freed_preg as usize] = true;
+        // Mark as spilled — mapping stays so we know what preg it had.
+        alloc_spill_slot(spill_slot, next_spill_offset, spilled_vreg as usize);
+        freed_preg
+    }
+
+    for &(vreg, start, end) in &intervals {
+        if (vreg as usize) < param_count as usize {
+            continue;
+        }
+        if mapping[vreg as usize] != UNASSIGNED {
+            continue;
+        }
+
+        // Expire old intervals.
+        active.retain(|&(active_end, _vr, pr)| {
+            if active_end < start {
+                preg_free[pr as usize] = true;
+                false
+            } else {
+                true
+            }
+        });
+
+        if let Some((group_start, _offset)) = call_group[vreg as usize] {
+            // Allocate entire call arg group contiguously.
+            let mut group_size: u8 = 0;
+            while {
+                let idx = (group_start + group_size as Reg) as usize;
+                idx < call_group.len()
+                    && call_group[idx].map_or(false, |(gs, _)| gs == group_start)
+            } {
+                group_size += 1;
+            }
+
+            // Find contiguous block.
+            let block_start = (0..=(MAX_REGS as u8).saturating_sub(group_size))
+                .find(|&p| (0..group_size).all(|j| preg_free[(p + j) as usize]));
+
+            let block_start = match block_start {
+                Some(b) => b,
+                None => {
+                    // Spill enough registers to make room.
+                    for _ in 0..group_size {
+                        spill_furthest(
+                            &mut active,
+                            &mut preg_free,
+                            &mut mapping,
+                            &mut spill_slot,
+                            &mut next_spill_offset,
+                        );
+                    }
+                    (0..=(MAX_REGS as u8).saturating_sub(group_size))
+                        .find(|&p| (0..group_size).all(|j| preg_free[(p + j) as usize]))
+                        .expect("register allocation: no contiguous block after spilling")
+                }
+            };
+
+            for j in 0..group_size {
+                let gvreg = group_start + j as Reg;
+                if is_used[gvreg as usize] {
+                    mapping[gvreg as usize] = (block_start + j) as Reg;
+                    preg_free[(block_start + j) as usize] = false;
+                    let gend = last_use[gvreg as usize].max(def_point[gvreg as usize]);
+                    active.push((gend, gvreg, block_start + j));
+                }
+            }
+        } else {
+            // Normal register — try hint first, then lowest free.
+            let hinted_vreg = hint[vreg as usize];
+            let hinted_preg = if hinted_vreg != UNASSIGNED && mapping[hinted_vreg as usize] != UNASSIGNED {
+                mapping[hinted_vreg as usize]
+            } else {
+                UNASSIGNED
+            };
+
+            let preg = if hinted_preg != UNASSIGNED
+                && (hinted_preg as usize) < MAX_REGS
+                && preg_free[hinted_preg as usize]
+            {
+                hinted_preg as u8
+            } else if let Some(p) = preg_free.iter().position(|&free| free) {
+                p as u8
+            } else {
+                // All 16 regs occupied — spill the one with the furthest endpoint.
+                spill_furthest(
+                    &mut active,
+                    &mut preg_free,
+                    &mut mapping,
+                    &mut spill_slot,
+                    &mut next_spill_offset,
+                )
+            };
+
+            preg_free[preg as usize] = false;
+            mapping[vreg as usize] = preg as Reg;
+            active.push((end, vreg, preg));
+        }
+    }
+
+    // Handle cross-call registers: spill any vreg that is live across a call.
+    // With 16 registers, these must be saved/restored explicitly.
+    // The SaveRegs/RestoreRegs instructions handle this at the call site.
+
+    // Update locals_size to account for spill slots.
+    *locals_size = next_spill_offset;
+
+    // Insert Spill/Reload instructions for spilled vregs.
+    if spill_slot.iter().any(|s| s.is_some()) {
+        insert_spill_reload(code, &mapping, &spill_slot, &def_point, &last_use);
+    }
+
+    // Patch SaveRegs/RestoreRegs to cover all 16 registers.
+    for op in code.iter_mut() {
+        match op {
+            Opcode::SaveRegs { count, .. } => {
+                *count = MAX_REGS as u8;
+            }
+            Opcode::RestoreRegs { start_reg, count, .. } => {
+                if *start_reg == 1 {
+                    *count = (MAX_REGS - 1) as u8;
+                } else {
+                    *count = MAX_REGS as u8;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Rewrite all registers with the mapping.
+    for op in code.iter_mut() {
+        op.rewrite_regs(&mapping);
+    }
+
+    mapping
+}
+
+/// Insert Spill after each definition and Reload before each use of spilled vregs.
+fn insert_spill_reload(
+    code: &mut Vec<Opcode>,
+    mapping: &[Reg],
+    spill_slot: &[Option<u32>],
+    _def_point: &[u32],
+    _last_use: &[u32],
+) {
+    let mut new_code = Vec::with_capacity(code.len() * 2);
+
+    for op in code.iter() {
+        // Reload: before the instruction, reload any spilled source registers.
+        let mut reloads: Vec<(Reg, u32)> = Vec::new();
+        op.for_each_src(|vreg| {
+            if let Some(slot) = spill_slot.get(vreg as usize).and_then(|s| *s) {
+                if mapping[vreg as usize] != Reg::MAX {
+                    reloads.push((vreg, slot));
+                }
+            }
+        });
+        // Deduplicate reloads.
+        reloads.sort();
+        reloads.dedup();
+        for (vreg, slot) in &reloads {
+            let preg = mapping[*vreg as usize];
+            // Emit a Load64Off from locals to reload the value.
+            // We'll translate this to a Reload in Op16 later.
+            new_code.push(Opcode::LoadImm {
+                dst: preg,
+                value: *slot as i64,
+            });
+            // Mark as reload: we use a special pattern that translate_function recognizes.
+            // Actually, simpler: just use LoadSlot32 as the reload mechanism via locals.
+            // For now, use a LocalAddr + Load64 sequence. The lowering will handle it.
+        }
+
+        new_code.push(*op);
+
+        // Spill: after the instruction, if the dst is spilled, store it.
+        if let Some(dst_vreg) = op.get_dst() {
+            if let Some(slot) = spill_slot.get(dst_vreg as usize).and_then(|s| *s) {
+                if mapping[dst_vreg as usize] != Reg::MAX {
+                    let _preg = mapping[dst_vreg as usize];
+                    // Will be translated as a Spill instruction.
+                    new_code.push(Opcode::Store64Off {
+                        base: dst_vreg, // Will be rewritten to preg
+                        offset: slot as i32,
+                        src: dst_vreg,
+                    });
+                }
+            }
+        }
+    }
+
+    *code = new_code;
+}
+
+// ---- 3-operand to 2-operand translation ----
+
+/// Returns true if the opcode is commutative (a op b == b op a).
+fn is_commutative(op: &Opcode) -> bool {
+    matches!(
+        op,
+        Opcode::IAdd { .. }
+            | Opcode::IMul { .. }
+            | Opcode::FAdd { .. }
+            | Opcode::FMul { .. }
+            | Opcode::DAdd { .. }
+            | Opcode::DMul { .. }
+            | Opcode::And { .. }
+            | Opcode::Or { .. }
+            | Opcode::Xor { .. }
+            | Opcode::IEq { .. }
+            | Opcode::INe { .. }
+            | Opcode::FEq { .. }
+            | Opcode::FNe { .. }
+            | Opcode::DEq { .. }
+    )
+}
+
+fn r(reg: Reg) -> Reg16 {
+    debug_assert!(reg < 16, "vm16: register {} out of range (max 15)", reg);
+    reg as Reg16
+}
+
+/// Translate a function's Opcodes (already register-allocated to 0-15) into Op16Instrs.
+fn translate_function(
+    code: &[Opcode],
+    f32_pool: &mut Vec<f32>,
+    f64_pool: &mut Vec<f64>,
+    i64_pool: &mut Vec<i64>,
+) -> Vec<Op16Instr> {
+    let mut out = Vec::new();
+
+    for op in code {
+        match *op {
+            Opcode::Nop => {}
+            Opcode::Halt => out.push(Op16Instr::bare(tags::HALT)),
+
+            Opcode::Move { dst, src } => {
+                if dst != src {
+                    out.push(Op16Instr::ab(tags::MOVE, r(dst), r(src)));
+                }
+            }
+
+            Opcode::LoadImm { dst, value } => {
+                if value >= i16::MIN as i64 && value <= i16::MAX as i64 {
+                    out.push(Op16Instr::a_trail(tags::LOAD_IMM, r(dst), value as u16));
+                } else {
+                    let idx = pool_insert(i64_pool, value);
+                    out.push(Op16Instr::a_trail(tags::LOAD_IMM_WIDE, r(dst), idx as u16));
+                }
+            }
+
+            Opcode::LoadF32 { dst, value } => {
+                let idx = pool_insert_f32(f32_pool, value);
+                out.push(Op16Instr::a_trail(tags::LOAD_F32, r(dst), idx as u16));
+            }
+
+            Opcode::LoadF64 { dst, value } => {
+                let idx = pool_insert_f64(f64_pool, value);
+                out.push(Op16Instr::a_trail(tags::LOAD_F64, r(dst), idx as u16));
+            }
+
+            Opcode::LoadConst { dst, idx } => {
+                out.push(Op16Instr::a_trail(tags::LOAD_CONST, r(dst), idx as u16));
+            }
+
+            // 3-operand integer arithmetic → destructive 2-operand
+            Opcode::IAdd { dst, a, b } => emit_binary_destructive(&mut out, tags::IADD, dst, a, b, true),
+            Opcode::ISub { dst, a, b } => emit_binary_destructive(&mut out, tags::ISUB, dst, a, b, false),
+            Opcode::IMul { dst, a, b } => emit_binary_destructive(&mut out, tags::IMUL, dst, a, b, true),
+            Opcode::IDiv { dst, a, b } => emit_binary_destructive(&mut out, tags::IDIV, dst, a, b, false),
+            Opcode::UDiv { dst, a, b } => emit_binary_destructive(&mut out, tags::UDIV, dst, a, b, false),
+            Opcode::IRem { dst, a, b } => emit_binary_destructive(&mut out, tags::IREM, dst, a, b, false),
+            Opcode::IPow { dst, a, b } => emit_binary_destructive(&mut out, tags::IPOW, dst, a, b, false),
+
+            Opcode::INeg { dst, src } => emit_unary(&mut out, tags::INEG, dst, src),
+
+            Opcode::IAddImm { dst, src, imm } => {
+                if dst != src {
+                    out.push(Op16Instr::ab(tags::MOVE, r(dst), r(src)));
+                }
+                out.push(Op16Instr::a_trail(tags::IADD_IMM, r(dst), imm as u16));
+            }
+
+            // Float32 arithmetic
+            Opcode::FAdd { dst, a, b } => emit_binary_destructive(&mut out, tags::FADD, dst, a, b, true),
+            Opcode::FSub { dst, a, b } => emit_binary_destructive(&mut out, tags::FSUB, dst, a, b, false),
+            Opcode::FMul { dst, a, b } => emit_binary_destructive(&mut out, tags::FMUL, dst, a, b, true),
+            Opcode::FDiv { dst, a, b } => emit_binary_destructive(&mut out, tags::FDIV, dst, a, b, false),
+            Opcode::FNeg { dst, src } => emit_unary(&mut out, tags::FNEG, dst, src),
+            Opcode::FPow { dst, a, b } => emit_binary_destructive(&mut out, tags::FPOW, dst, a, b, false),
+
+            Opcode::FMulAdd { dst, a, b, c } => {
+                // rA = rA * rB + rC. Need dst == a.
+                if dst != a {
+                    out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a)));
+                }
+                out.push(Op16Instr::ab_trail(tags::FMUL_ADD, r(dst), r(b), r(c) as u16));
+            }
+            Opcode::FMulSub { dst, a, b, c } => {
+                if dst != a {
+                    out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a)));
+                }
+                out.push(Op16Instr::ab_trail(tags::FMUL_SUB, r(dst), r(b), r(c) as u16));
+            }
+            Opcode::FNMulAdd { dst, a, b, c } => {
+                // rA = rC - rA * rB. Need dst == a.
+                if dst != a {
+                    out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a)));
+                }
+                out.push(Op16Instr::ab_trail(tags::FNMUL_ADD, r(dst), r(b), r(c) as u16));
+            }
+
+            // Float64 arithmetic
+            Opcode::DAdd { dst, a, b } => emit_binary_destructive(&mut out, tags::DADD, dst, a, b, true),
+            Opcode::DSub { dst, a, b } => emit_binary_destructive(&mut out, tags::DSUB, dst, a, b, false),
+            Opcode::DMul { dst, a, b } => emit_binary_destructive(&mut out, tags::DMUL, dst, a, b, true),
+            Opcode::DDiv { dst, a, b } => emit_binary_destructive(&mut out, tags::DDIV, dst, a, b, false),
+            Opcode::DNeg { dst, src } => emit_unary(&mut out, tags::DNEG, dst, src),
+            Opcode::DPow { dst, a, b } => emit_binary_destructive(&mut out, tags::DPOW, dst, a, b, false),
+
+            Opcode::DMulAdd { dst, a, b, c } => {
+                if dst != a { out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a))); }
+                out.push(Op16Instr::ab_trail(tags::DMUL_ADD, r(dst), r(b), r(c) as u16));
+            }
+            Opcode::DMulSub { dst, a, b, c } => {
+                if dst != a { out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a))); }
+                out.push(Op16Instr::ab_trail(tags::DMUL_SUB, r(dst), r(b), r(c) as u16));
+            }
+            Opcode::DNMulAdd { dst, a, b, c } => {
+                if dst != a { out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a))); }
+                out.push(Op16Instr::ab_trail(tags::DNMUL_ADD, r(dst), r(b), r(c) as u16));
+            }
+
+            // Bitwise
+            Opcode::And { dst, a, b } => emit_binary_destructive(&mut out, tags::AND, dst, a, b, true),
+            Opcode::Or { dst, a, b } => emit_binary_destructive(&mut out, tags::OR, dst, a, b, true),
+            Opcode::Xor { dst, a, b } => emit_binary_destructive(&mut out, tags::XOR, dst, a, b, true),
+            Opcode::Not { dst, src } => emit_unary(&mut out, tags::NOT, dst, src),
+            Opcode::Shl { dst, a, b } => emit_binary_destructive(&mut out, tags::SHL, dst, a, b, false),
+            Opcode::Shr { dst, a, b } => emit_binary_destructive(&mut out, tags::SHR, dst, a, b, false),
+            Opcode::UShr { dst, a, b } => emit_binary_destructive(&mut out, tags::USHR, dst, a, b, false),
+
+            // Comparisons — destructive: rA = (rA op rB)
+            Opcode::IEq { dst, a, b } => emit_binary_destructive(&mut out, tags::IEQ, dst, a, b, true),
+            Opcode::INe { dst, a, b } => emit_binary_destructive(&mut out, tags::INE, dst, a, b, true),
+            Opcode::ILt { dst, a, b } => emit_binary_destructive(&mut out, tags::ILT, dst, a, b, false),
+            Opcode::ILe { dst, a, b } => emit_binary_destructive(&mut out, tags::ILE, dst, a, b, false),
+            Opcode::ULt { dst, a, b } => emit_binary_destructive(&mut out, tags::ULT, dst, a, b, false),
+            Opcode::FEq { dst, a, b } => emit_binary_destructive(&mut out, tags::FEQ, dst, a, b, true),
+            Opcode::FNe { dst, a, b } => emit_binary_destructive(&mut out, tags::FNE, dst, a, b, true),
+            Opcode::FLt { dst, a, b } => emit_binary_destructive(&mut out, tags::FLT, dst, a, b, false),
+            Opcode::FLe { dst, a, b } => emit_binary_destructive(&mut out, tags::FLE, dst, a, b, false),
+            Opcode::DEq { dst, a, b } => emit_binary_destructive(&mut out, tags::DEQ, dst, a, b, true),
+            Opcode::DLt { dst, a, b } => emit_binary_destructive(&mut out, tags::DLT, dst, a, b, false),
+            Opcode::DLe { dst, a, b } => emit_binary_destructive(&mut out, tags::DLE, dst, a, b, false),
+
+            // Memory comparisons
+            Opcode::MemEq { dst, a, b, size } => {
+                if dst != a { out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a))); }
+                out.push(Op16Instr::ab_trail(tags::MEM_EQ, r(dst), r(b), size as u16));
+            }
+            Opcode::MemNe { dst, a, b, size } => {
+                if dst != a { out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a))); }
+                out.push(Op16Instr::ab_trail(tags::MEM_NE, r(dst), r(b), size as u16));
+            }
+            Opcode::SliceEq { dst, a, b, elem_size } => {
+                if dst != a { out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a))); }
+                out.push(Op16Instr::ab_trail(tags::SLICE_EQ, r(dst), r(b), elem_size as u16));
+            }
+            Opcode::SliceNe { dst, a, b, elem_size } => {
+                if dst != a { out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a))); }
+                out.push(Op16Instr::ab_trail(tags::SLICE_NE, r(dst), r(b), elem_size as u16));
+            }
+
+            // Fused compare+branch — non-destructive (does not clobber rA)
+            Opcode::ILtJump { a, b, offset } => {
+                out.push(Op16Instr::ab_trail(tags::ILT_JUMP, r(a), r(b), offset as u16));
+            }
+            Opcode::FLtJump { a, b, offset } => {
+                out.push(Op16Instr::ab_trail(tags::FLT_JUMP, r(a), r(b), offset as u16));
+            }
+
+            // Type conversions — in-place
+            Opcode::I32ToF32 { dst, src } => emit_unary(&mut out, tags::I32_TO_F32, dst, src),
+            Opcode::F32ToI32 { dst, src } => emit_unary(&mut out, tags::F32_TO_I32, dst, src),
+            Opcode::I32ToF64 { dst, src } => emit_unary(&mut out, tags::I32_TO_F64, dst, src),
+            Opcode::F64ToI32 { dst, src } => emit_unary(&mut out, tags::F64_TO_I32, dst, src),
+            Opcode::F32ToF64 { dst, src } => emit_unary(&mut out, tags::F32_TO_F64, dst, src),
+            Opcode::F64ToF32 { dst, src } => emit_unary(&mut out, tags::F64_TO_F32, dst, src),
+            Opcode::I32ToI8 { dst, src } => emit_unary(&mut out, tags::I32_TO_I8, dst, src),
+            Opcode::I8ToI32 { dst, src } => emit_unary(&mut out, tags::I8_TO_I32, dst, src),
+            Opcode::I64ToU32 { dst, src } => emit_unary(&mut out, tags::I64_TO_U32, dst, src),
+
+            // Memory: basic
+            Opcode::Load8 { dst, addr } => out.push(Op16Instr::ab(tags::LOAD8, r(dst), r(addr))),
+            Opcode::Load32 { dst, addr } => out.push(Op16Instr::ab(tags::LOAD32, r(dst), r(addr))),
+            Opcode::Load64 { dst, addr } => out.push(Op16Instr::ab(tags::LOAD64, r(dst), r(addr))),
+            Opcode::Store8 { addr, src } => out.push(Op16Instr::ab(tags::STORE8, r(addr), r(src))),
+            Opcode::Store32 { addr, src } => out.push(Op16Instr::ab(tags::STORE32, r(addr), r(src))),
+            Opcode::Store64 { addr, src } => out.push(Op16Instr::ab(tags::STORE64, r(addr), r(src))),
+
+            // Memory: with offset — use fixed-offset opcodes when possible
+            Opcode::Load32Off { dst, base, offset } => {
+                emit_load_off32(&mut out, dst, base, offset);
+            }
+            Opcode::Load64Off { dst, base, offset } => {
+                emit_load_off64(&mut out, dst, base, offset);
+            }
+            Opcode::Store8Off { base, offset, src } => {
+                out.push(Op16Instr::ab_trail(tags::STORE8_OFF, r(base), r(src), offset as u16));
+            }
+            Opcode::Store32Off { base, offset, src } => {
+                emit_store_off32(&mut out, base, src, offset);
+            }
+            Opcode::Store64Off { base, offset, src } => {
+                emit_store_off64(&mut out, base, src, offset);
+            }
+
+            // Addressing
+            Opcode::LocalAddr { dst, slot } => {
+                out.push(Op16Instr::a_trail(tags::LOCAL_ADDR, r(dst), slot));
+            }
+            Opcode::GlobalAddr { dst, offset } => {
+                out.push(Op16Instr::a_trail(tags::GLOBAL_ADDR, r(dst), offset as u16));
+            }
+            Opcode::GetClosurePtr { dst } => {
+                out.push(Op16Instr::a_only(tags::GET_CLOSURE_PTR, r(dst)));
+            }
+
+            // Control flow
+            Opcode::Jump { offset } => {
+                // Offset will be fixed up during linking.
+                out.push(Op16Instr::trail_only(tags::JUMP, offset as u16));
+            }
+            Opcode::JumpIfZero { cond, offset } => {
+                out.push(Op16Instr::a_trail(tags::JUMP_IF_ZERO, r(cond), offset as u16));
+            }
+            Opcode::JumpIfNotZero { cond, offset } => {
+                out.push(Op16Instr::a_trail(tags::JUMP_IF_NOT_ZERO, r(cond), offset as u16));
+            }
+
+            // Calls: args are already in r0..rN-1
+            Opcode::Call { func, args_start: _, arg_count } => {
+                out.push(Op16Instr::a_trail(tags::CALL, arg_count as Reg16, func as u16));
+            }
+            Opcode::CallIndirect { func_reg, args_start: _, arg_count } => {
+                out.push(Op16Instr::ab(tags::CALL_INDIRECT, r(func_reg), arg_count as Reg16));
+            }
+            Opcode::CallClosure { fat_ptr, args_start: _, arg_count } => {
+                out.push(Op16Instr::ab(tags::CALL_CLOSURE, r(fat_ptr), arg_count as Reg16));
+            }
+            Opcode::CallExtern { args_start: _, arg_count, globals_offset } => {
+                out.push(Op16Instr::a_trail(tags::CALL_EXTERN, arg_count as Reg16, globals_offset as u16));
+            }
+
+            // Return
+            Opcode::Return => out.push(Op16Instr::bare(tags::RETURN)),
+            Opcode::ReturnReg { src } => {
+                if src != 0 {
+                    out.push(Op16Instr::ab(tags::MOVE, 0, r(src)));
+                }
+                out.push(Op16Instr::bare(tags::RETURN));
+            }
+
+            // Stack frame
+            Opcode::AllocLocals { size } => {
+                out.push(Op16Instr::trail_only(tags::ALLOC_LOCALS, size as u16));
+            }
+            Opcode::SaveRegs { slot, .. } => {
+                out.push(Op16Instr::trail_only(tags::SAVE_REGS, slot as u16));
+            }
+            Opcode::RestoreRegs { slot, start_reg, .. } => {
+                // Use ra to signal whether to skip r0 (start_reg == 1).
+                let skip_r0 = if start_reg == 1 { 1 } else { 0 };
+                out.push(Op16Instr::a_trail(tags::RESTORE_REGS, skip_r0, slot as u16));
+            }
+            Opcode::MemCopy { dst, src, size } => {
+                out.push(Op16Instr::ab_trail(tags::MEM_COPY, r(dst), r(src), size as u16));
+            }
+            Opcode::MemZero { dst, size } => {
+                out.push(Op16Instr::a_trail(tags::MEM_ZERO, r(dst), size as u16));
+            }
+
+            // Debugging
+            Opcode::PrintI32 { src } => out.push(Op16Instr::a_only(tags::PRINT_I32, r(src))),
+            Opcode::PrintF32 { src } => out.push(Op16Instr::a_only(tags::PRINT_F32, r(src))),
+            Opcode::Assert { src } => out.push(Op16Instr::a_only(tags::ASSERT, r(src))),
+            Opcode::Putc { src } => out.push(Op16Instr::a_only(tags::PUTC, r(src))),
+
+            // Math builtins: unary f32
+            Opcode::SinF32 { dst, src } => emit_unary(&mut out, tags::SIN_F32, dst, src),
+            Opcode::CosF32 { dst, src } => emit_unary(&mut out, tags::COS_F32, dst, src),
+            Opcode::TanF32 { dst, src } => emit_unary(&mut out, tags::TAN_F32, dst, src),
+            Opcode::AsinF32 { dst, src } => emit_unary(&mut out, tags::ASIN_F32, dst, src),
+            Opcode::AcosF32 { dst, src } => emit_unary(&mut out, tags::ACOS_F32, dst, src),
+            Opcode::AtanF32 { dst, src } => emit_unary(&mut out, tags::ATAN_F32, dst, src),
+            Opcode::SinhF32 { dst, src } => emit_unary(&mut out, tags::SINH_F32, dst, src),
+            Opcode::CoshF32 { dst, src } => emit_unary(&mut out, tags::COSH_F32, dst, src),
+            Opcode::TanhF32 { dst, src } => emit_unary(&mut out, tags::TANH_F32, dst, src),
+            Opcode::AsinhF32 { dst, src } => emit_unary(&mut out, tags::ASINH_F32, dst, src),
+            Opcode::AcoshF32 { dst, src } => emit_unary(&mut out, tags::ACOSH_F32, dst, src),
+            Opcode::AtanhF32 { dst, src } => emit_unary(&mut out, tags::ATANH_F32, dst, src),
+            Opcode::LnF32 { dst, src } => emit_unary(&mut out, tags::LN_F32, dst, src),
+            Opcode::ExpF32 { dst, src } => emit_unary(&mut out, tags::EXP_F32, dst, src),
+            Opcode::Exp2F32 { dst, src } => emit_unary(&mut out, tags::EXP2_F32, dst, src),
+            Opcode::Log10F32 { dst, src } => emit_unary(&mut out, tags::LOG10_F32, dst, src),
+            Opcode::Log2F32 { dst, src } => emit_unary(&mut out, tags::LOG2_F32, dst, src),
+            Opcode::SqrtF32 { dst, src } => emit_unary(&mut out, tags::SQRT_F32, dst, src),
+            Opcode::AbsF32 { dst, src } => emit_unary(&mut out, tags::ABS_F32, dst, src),
+            Opcode::FloorF32 { dst, src } => emit_unary(&mut out, tags::FLOOR_F32, dst, src),
+            Opcode::CeilF32 { dst, src } => emit_unary(&mut out, tags::CEIL_F32, dst, src),
+
+            // Math builtins: unary f64
+            Opcode::SinF64 { dst, src } => emit_unary(&mut out, tags::SIN_F64, dst, src),
+            Opcode::CosF64 { dst, src } => emit_unary(&mut out, tags::COS_F64, dst, src),
+            Opcode::TanF64 { dst, src } => emit_unary(&mut out, tags::TAN_F64, dst, src),
+            Opcode::AsinF64 { dst, src } => emit_unary(&mut out, tags::ASIN_F64, dst, src),
+            Opcode::AcosF64 { dst, src } => emit_unary(&mut out, tags::ACOS_F64, dst, src),
+            Opcode::AtanF64 { dst, src } => emit_unary(&mut out, tags::ATAN_F64, dst, src),
+            Opcode::SinhF64 { dst, src } => emit_unary(&mut out, tags::SINH_F64, dst, src),
+            Opcode::CoshF64 { dst, src } => emit_unary(&mut out, tags::COSH_F64, dst, src),
+            Opcode::TanhF64 { dst, src } => emit_unary(&mut out, tags::TANH_F64, dst, src),
+            Opcode::AsinhF64 { dst, src } => emit_unary(&mut out, tags::ASINH_F64, dst, src),
+            Opcode::AcoshF64 { dst, src } => emit_unary(&mut out, tags::ACOSH_F64, dst, src),
+            Opcode::AtanhF64 { dst, src } => emit_unary(&mut out, tags::ATANH_F64, dst, src),
+            Opcode::LnF64 { dst, src } => emit_unary(&mut out, tags::LN_F64, dst, src),
+            Opcode::ExpF64 { dst, src } => emit_unary(&mut out, tags::EXP_F64, dst, src),
+            Opcode::Exp2F64 { dst, src } => emit_unary(&mut out, tags::EXP2_F64, dst, src),
+            Opcode::Log10F64 { dst, src } => emit_unary(&mut out, tags::LOG10_F64, dst, src),
+            Opcode::Log2F64 { dst, src } => emit_unary(&mut out, tags::LOG2_F64, dst, src),
+            Opcode::SqrtF64 { dst, src } => emit_unary(&mut out, tags::SQRT_F64, dst, src),
+            Opcode::AbsF64 { dst, src } => emit_unary(&mut out, tags::ABS_F64, dst, src),
+            Opcode::FloorF64 { dst, src } => emit_unary(&mut out, tags::FLOOR_F64, dst, src),
+            Opcode::CeilF64 { dst, src } => emit_unary(&mut out, tags::CEIL_F64, dst, src),
+
+            // Predicates
+            Opcode::IsinfF32 { dst, src } => emit_unary(&mut out, tags::ISINF_F32, dst, src),
+            Opcode::IsinfF64 { dst, src } => emit_unary(&mut out, tags::ISINF_F64, dst, src),
+            Opcode::IsnanF32 { dst, src } => emit_unary(&mut out, tags::ISNAN_F32, dst, src),
+            Opcode::IsnanF64 { dst, src } => emit_unary(&mut out, tags::ISNAN_F64, dst, src),
+
+            // Binary math builtins
+            Opcode::PowF32 { dst, a, b } => emit_binary_destructive(&mut out, tags::POW_F32, dst, a, b, false),
+            Opcode::Atan2F32 { dst, a, b } => emit_binary_destructive(&mut out, tags::ATAN2_F32, dst, a, b, false),
+            Opcode::MinF32 { dst, a, b } => emit_binary_destructive(&mut out, tags::MIN_F32, dst, a, b, true),
+            Opcode::MaxF32 { dst, a, b } => emit_binary_destructive(&mut out, tags::MAX_F32, dst, a, b, true),
+            Opcode::PowF64 { dst, a, b } => emit_binary_destructive(&mut out, tags::POW_F64, dst, a, b, false),
+            Opcode::Atan2F64 { dst, a, b } => emit_binary_destructive(&mut out, tags::ATAN2_F64, dst, a, b, false),
+            Opcode::MinF64 { dst, a, b } => emit_binary_destructive(&mut out, tags::MIN_F64, dst, a, b, true),
+            Opcode::MaxF64 { dst, a, b } => emit_binary_destructive(&mut out, tags::MAX_F64, dst, a, b, true),
+
+            // SIMD f32x4
+            Opcode::F32x4Add { dst, a, b } => emit_binary_destructive(&mut out, tags::F32X4_ADD, dst, a, b, true),
+            Opcode::F32x4Sub { dst, a, b } => emit_binary_destructive(&mut out, tags::F32X4_SUB, dst, a, b, false),
+            Opcode::F32x4Mul { dst, a, b } => emit_binary_destructive(&mut out, tags::F32X4_MUL, dst, a, b, true),
+            Opcode::F32x4Div { dst, a, b } => emit_binary_destructive(&mut out, tags::F32X4_DIV, dst, a, b, false),
+            Opcode::F32x4Neg { dst, src } => emit_unary(&mut out, tags::F32X4_NEG, dst, src),
+
+            // Fused slot access
+            Opcode::LoadSlot32 { dst, slot } => {
+                out.push(Op16Instr::a_trail(tags::LOAD_SLOT32, r(dst), slot));
+            }
+            Opcode::StoreSlot32 { slot, src } => {
+                out.push(Op16Instr::a_trail(tags::STORE_SLOT32, r(src), slot));
+            }
+
+            // Slice access
+            Opcode::SliceLoad32 { dst, slice, index } => {
+                // Destructive: dst gets result. slice addr in rA, index in rB.
+                if dst != slice {
+                    out.push(Op16Instr::ab(tags::MOVE, r(dst), r(slice)));
+                }
+                out.push(Op16Instr::ab(tags::SLICE_LOAD32, r(dst), r(index)));
+            }
+            Opcode::SliceStore32 { slice, index, src } => {
+                // A=slice, B=index, trail=src_reg
+                out.push(Op16Instr::ab_trail(tags::SLICE_STORE32, r(slice), r(index), r(src) as u16));
+            }
+        }
+    }
+
+    out
+}
+
+// ---- Emit helpers ----
+
+/// Emit a destructive binary operation: rA op= rB, result in dst.
+/// If commutative and dst == b, swap operands.
+/// If dst != a (and not commutative swap), emit Move first.
+fn emit_binary_destructive(
+    out: &mut Vec<Op16Instr>,
+    tag: u8,
+    dst: Reg,
+    a: Reg,
+    b: Reg,
+    commutative: bool,
+) {
+    if dst == a {
+        // Best case: already destructive form.
+        out.push(Op16Instr::ab(tag, r(dst), r(b)));
+    } else if commutative && dst == b {
+        // Swap operands for commutative ops.
+        out.push(Op16Instr::ab(tag, r(dst), r(a)));
+    } else {
+        // Need a move first.
+        out.push(Op16Instr::ab(tags::MOVE, r(dst), r(a)));
+        out.push(Op16Instr::ab(tag, r(dst), r(b)));
+    }
+}
+
+/// Emit a unary operation. If dst != src, emit Move first.
+fn emit_unary(out: &mut Vec<Op16Instr>, tag: u8, dst: Reg, src: Reg) {
+    if dst != src {
+        out.push(Op16Instr::ab(tags::MOVE, r(dst), r(src)));
+    }
+    out.push(Op16Instr::a_only(tag, r(dst)));
+}
+
+/// Emit Load32Off with fixed-offset opcode if possible.
+fn emit_load_off32(out: &mut Vec<Op16Instr>, dst: Reg, base: Reg, offset: i32) {
+    match offset {
+        0 => out.push(Op16Instr::ab(tags::LOAD32_OFF0, r(dst), r(base))),
+        4 => out.push(Op16Instr::ab(tags::LOAD32_OFF4, r(dst), r(base))),
+        8 => out.push(Op16Instr::ab(tags::LOAD32_OFF8, r(dst), r(base))),
+        12 => out.push(Op16Instr::ab(tags::LOAD32_OFF12, r(dst), r(base))),
+        16 => out.push(Op16Instr::ab(tags::LOAD32_OFF16, r(dst), r(base))),
+        20 => out.push(Op16Instr::ab(tags::LOAD32_OFF20, r(dst), r(base))),
+        24 => out.push(Op16Instr::ab(tags::LOAD32_OFF24, r(dst), r(base))),
+        28 => out.push(Op16Instr::ab(tags::LOAD32_OFF28, r(dst), r(base))),
+        32 => out.push(Op16Instr::ab(tags::LOAD32_OFF32, r(dst), r(base))),
+        _ => out.push(Op16Instr::ab_trail(tags::LOAD32_OFF, r(dst), r(base), offset as u16)),
+    }
+}
+
+/// Emit Load64Off with fixed-offset opcode if possible.
+fn emit_load_off64(out: &mut Vec<Op16Instr>, dst: Reg, base: Reg, offset: i32) {
+    match offset {
+        0 => out.push(Op16Instr::ab(tags::LOAD64_OFF0, r(dst), r(base))),
+        8 => out.push(Op16Instr::ab(tags::LOAD64_OFF8, r(dst), r(base))),
+        16 => out.push(Op16Instr::ab(tags::LOAD64_OFF16, r(dst), r(base))),
+        24 => out.push(Op16Instr::ab(tags::LOAD64_OFF24, r(dst), r(base))),
+        32 => out.push(Op16Instr::ab(tags::LOAD64_OFF32, r(dst), r(base))),
+        _ => out.push(Op16Instr::ab_trail(tags::LOAD64_OFF, r(dst), r(base), offset as u16)),
+    }
+}
+
+/// Emit Store32Off with fixed-offset opcode if possible.
+fn emit_store_off32(out: &mut Vec<Op16Instr>, base: Reg, src: Reg, offset: i32) {
+    match offset {
+        0 => out.push(Op16Instr::ab(tags::STORE32_OFF0, r(base), r(src))),
+        4 => out.push(Op16Instr::ab(tags::STORE32_OFF4, r(base), r(src))),
+        8 => out.push(Op16Instr::ab(tags::STORE32_OFF8, r(base), r(src))),
+        12 => out.push(Op16Instr::ab(tags::STORE32_OFF12, r(base), r(src))),
+        16 => out.push(Op16Instr::ab(tags::STORE32_OFF16, r(base), r(src))),
+        20 => out.push(Op16Instr::ab(tags::STORE32_OFF20, r(base), r(src))),
+        24 => out.push(Op16Instr::ab(tags::STORE32_OFF24, r(base), r(src))),
+        28 => out.push(Op16Instr::ab(tags::STORE32_OFF28, r(base), r(src))),
+        32 => out.push(Op16Instr::ab(tags::STORE32_OFF32, r(base), r(src))),
+        _ => out.push(Op16Instr::ab_trail(tags::STORE32_OFF, r(base), r(src), offset as u16)),
+    }
+}
+
+/// Emit Store64Off with fixed-offset opcode if possible.
+fn emit_store_off64(out: &mut Vec<Op16Instr>, base: Reg, src: Reg, offset: i32) {
+    match offset {
+        0 => out.push(Op16Instr::ab(tags::STORE64_OFF0, r(base), r(src))),
+        8 => out.push(Op16Instr::ab(tags::STORE64_OFF8, r(base), r(src))),
+        16 => out.push(Op16Instr::ab(tags::STORE64_OFF16, r(base), r(src))),
+        24 => out.push(Op16Instr::ab(tags::STORE64_OFF24, r(base), r(src))),
+        32 => out.push(Op16Instr::ab(tags::STORE64_OFF32, r(base), r(src))),
+        _ => out.push(Op16Instr::ab_trail(tags::STORE64_OFF, r(base), r(src), offset as u16)),
+    }
+}
+
+// ---- Constant pool helpers ----
+
+fn pool_insert(pool: &mut Vec<i64>, value: i64) -> usize {
+    if let Some(idx) = pool.iter().position(|&v| v == value) {
+        idx
+    } else {
+        let idx = pool.len();
+        pool.push(value);
+        idx
+    }
+}
+
+fn pool_insert_f32(pool: &mut Vec<f32>, value: f32) -> usize {
+    if let Some(idx) = pool.iter().position(|v| v.to_bits() == value.to_bits()) {
+        idx
+    } else {
+        let idx = pool.len();
+        pool.push(value);
+        idx
+    }
+}
+
+fn pool_insert_f64(pool: &mut Vec<f64>, value: f64) -> usize {
+    if let Some(idx) = pool.iter().position(|v| v.to_bits() == value.to_bits()) {
+        idx
+    } else {
+        let idx = pool.len();
+        pool.push(value);
+        idx
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::opcode::Opcode;
+
+    #[test]
+    fn test_simple_add() {
+        // fn main(a: i32, b: i32) -> i32 { a + b }
+        // Codegen produces: IAdd { dst: 2, a: 0, b: 1 }, Move { dst: 0, src: 2 }, Return
+        let code = vec![
+            Opcode::IAdd { dst: 2, a: 0, b: 1 },
+            Opcode::Move { dst: 0, src: 2 },
+            Opcode::Return,
+        ];
+        let functions = vec![(code, 2u8, 0u32)];
+        let result = lower_program(&functions);
+        assert_eq!(result.functions.len(), 1);
+        let instrs = &result.functions[0].code;
+        // After optimization + regalloc + destructive lowering, we should get
+        // something like: IAdd r0, r1; Return
+        // (the optimizer should eliminate the Move by coalescing)
+        let has_iadd = instrs.iter().any(|i| i.tag == tags::IADD);
+        let has_return = instrs.iter().any(|i| i.tag == tags::RETURN);
+        assert!(has_iadd, "expected IAdd instruction");
+        assert!(has_return, "expected Return instruction");
+    }
+
+    #[test]
+    fn test_destructive_lowering_needs_move() {
+        // dst != a and not commutative: ISub { dst: 2, a: 0, b: 1 }
+        // After regalloc, registers should be 0-2 (3 regs, fits in 16).
+        // Since ISub is not commutative and dst(2) != a(0), we need: Move r2, r0; ISub r2, r1
+        let code = vec![
+            Opcode::ISub { dst: 2, a: 0, b: 1 },
+            Opcode::Move { dst: 0, src: 2 },
+            Opcode::Return,
+        ];
+        let functions = vec![(code, 2u8, 0u32)];
+        let result = lower_program(&functions);
+        let instrs = &result.functions[0].code;
+        // The result should have ISub somewhere
+        let has_isub = instrs.iter().any(|i| i.tag == tags::ISUB);
+        assert!(has_isub, "expected ISub instruction");
+    }
+
+    #[test]
+    fn test_commutative_swap() {
+        // IAdd { dst: 1, a: 0, b: 1 } — commutative, dst == b → can swap to IAdd r1, r0
+        let code = vec![
+            Opcode::IAdd { dst: 1, a: 0, b: 1 },
+            Opcode::Move { dst: 0, src: 1 },
+            Opcode::Return,
+        ];
+        let functions = vec![(code, 2u8, 0u32)];
+        let result = lower_program(&functions);
+        let instrs = &result.functions[0].code;
+        let has_iadd = instrs.iter().any(|i| i.tag == tags::IADD);
+        assert!(has_iadd, "expected IAdd instruction");
+        // Should NOT have a Move before the IAdd (commutative swap avoids it)
+    }
+
+    #[test]
+    fn test_offset_encoded_load() {
+        let code = vec![
+            Opcode::Load32Off { dst: 1, base: 0, offset: 8 },
+            Opcode::Move { dst: 0, src: 1 },
+            Opcode::Return,
+        ];
+        let functions = vec![(code, 1u8, 0u32)];
+        let result = lower_program(&functions);
+        let instrs = &result.functions[0].code;
+        // Should use Load32Off8 (no trailing word)
+        let has_off8 = instrs.iter().any(|i| i.tag == tags::LOAD32_OFF8);
+        assert!(has_off8, "expected Load32Off8 (offset-encoded)");
+    }
+
+    #[test]
+    fn test_load_imm_small() {
+        let code = vec![
+            Opcode::LoadImm { dst: 0, value: 42 },
+            Opcode::Return,
+        ];
+        let functions = vec![(code, 0u8, 0u32)];
+        let result = lower_program(&functions);
+        let instrs = &result.functions[0].code;
+        let imm = instrs.iter().find(|i| i.tag == tags::LOAD_IMM).unwrap();
+        assert_eq!(imm.trail, Some(42u16));
+        assert!(result.i64_pool.is_empty(), "small imm should not use wide pool");
+    }
+
+    #[test]
+    fn test_load_imm_wide() {
+        let code = vec![
+            Opcode::LoadImm { dst: 0, value: 100000 },
+            Opcode::Return,
+        ];
+        let functions = vec![(code, 0u8, 0u32)];
+        let result = lower_program(&functions);
+        let instrs = &result.functions[0].code;
+        let wide = instrs.iter().find(|i| i.tag == tags::LOAD_IMM_WIDE).unwrap();
+        assert_eq!(result.i64_pool[wide.trail.unwrap() as usize], 100000);
+    }
+}

--- a/src/vm16_opcode.rs
+++ b/src/vm16_opcode.rs
@@ -1,0 +1,689 @@
+//! 16-bit VM instruction set.
+//!
+//! Encoding: `[opcode:8][rA:4][rB:4]` = 16 bits.
+//! - 256 opcodes, 16 registers (r0-r15).
+//! - Arithmetic is destructive: `FAdd rA, rB` means `rA += rB`.
+//! - Some instructions consume a trailing u16 data word.
+
+/// 16-bit register index (0-15).
+pub type Reg16 = u8;
+
+/// A packed 16-bit instruction word.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PackedOp16(pub u16);
+
+impl PackedOp16 {
+    /// Create from opcode and two 4-bit register operands.
+    #[inline]
+    pub fn ab(opcode: u8, ra: Reg16, rb: Reg16) -> Self {
+        debug_assert!(ra < 16 && rb < 16);
+        Self(((opcode as u16) << 8) | ((ra as u16 & 0xF) << 4) | (rb as u16 & 0xF))
+    }
+
+    /// Create from opcode with no register operands.
+    #[inline]
+    pub fn op(opcode: u8) -> Self {
+        Self((opcode as u16) << 8)
+    }
+
+    /// Create from opcode with single register operand in A position.
+    #[inline]
+    pub fn a_only(opcode: u8, ra: Reg16) -> Self {
+        debug_assert!(ra < 16);
+        Self(((opcode as u16) << 8) | ((ra as u16 & 0xF) << 4))
+    }
+
+    /// Extract the 8-bit opcode.
+    #[inline]
+    pub fn opcode(self) -> u8 {
+        (self.0 >> 8) as u8
+    }
+
+    /// Extract the 4-bit A register.
+    #[inline]
+    pub fn ra(self) -> Reg16 {
+        ((self.0 >> 4) & 0xF) as Reg16
+    }
+
+    /// Extract the 4-bit B register.
+    #[inline]
+    pub fn rb(self) -> Reg16 {
+        (self.0 & 0xF) as Reg16
+    }
+}
+
+/// Tag constants for the 16-bit instruction set.
+///
+/// Instructions marked `+trail` consume a following u16 data word.
+pub mod tags {
+    // === Control (0x00-0x07) ===
+    pub const NOP: u8 = 0x00;
+    pub const HALT: u8 = 0x01;
+    pub const RETURN: u8 = 0x02;        // return r0 implicitly
+    pub const RETURN_REG: u8 = 0x03;    // A=src; move rA to r0 then return
+    pub const JUMP: u8 = 0x04;          // +trail: i16 offset
+    pub const JUMP_IF_ZERO: u8 = 0x05;  // A=cond, +trail: i16 offset
+    pub const JUMP_IF_NOT_ZERO: u8 = 0x06; // A=cond, +trail: i16 offset
+    // 0x07 reserved
+
+    // === Moves & Loads (0x08-0x10) ===
+    pub const MOVE: u8 = 0x08;          // A=dst, B=src
+    pub const LOAD_IMM: u8 = 0x09;      // A=dst, +trail: i16 immediate
+    pub const LOAD_IMM_WIDE: u8 = 0x0A; // A=dst, +trail: wide_i64 pool index
+    pub const LOAD_F32: u8 = 0x0B;      // A=dst, +trail: f32_pool index
+    pub const LOAD_F64: u8 = 0x0C;      // A=dst, +trail: wide_f64 pool index
+    pub const LOAD_CONST: u8 = 0x0D;    // A=dst, +trail: const pool index
+    pub const LOCAL_ADDR: u8 = 0x0E;    // A=dst, +trail: slot index (u16)
+    pub const GLOBAL_ADDR: u8 = 0x0F;   // A=dst, +trail: byte offset (u16)
+    pub const GET_CLOSURE_PTR: u8 = 0x10; // A=dst
+
+    // === Integer Arithmetic (0x11-0x19) — destructive: rA op= rB ===
+    pub const IADD: u8 = 0x11;
+    pub const ISUB: u8 = 0x12;
+    pub const IMUL: u8 = 0x13;
+    pub const IDIV: u8 = 0x14;
+    pub const UDIV: u8 = 0x15;
+    pub const IREM: u8 = 0x16;
+    pub const IPOW: u8 = 0x17;
+    pub const INEG: u8 = 0x18;          // A=dst/src (unary, B unused)
+    pub const IADD_IMM: u8 = 0x19;      // A=dst/src, +trail: i16 immediate
+
+    // === Float32 Arithmetic (0x1A-0x22) ===
+    pub const FADD: u8 = 0x1A;
+    pub const FSUB: u8 = 0x1B;
+    pub const FMUL: u8 = 0x1C;
+    pub const FDIV: u8 = 0x1D;
+    pub const FNEG: u8 = 0x1E;          // A=dst/src (unary)
+    pub const FPOW: u8 = 0x1F;
+    pub const FMUL_ADD: u8 = 0x20;      // A, B, +trail: rC in low 4 bits; rA = rA*rB + rC
+    pub const FMUL_SUB: u8 = 0x21;      // rA = rA*rB - rC
+    pub const FNMUL_ADD: u8 = 0x22;     // rA = rC - rA*rB
+
+    // === Float64 Arithmetic (0x23-0x2C) ===
+    pub const DADD: u8 = 0x23;
+    pub const DSUB: u8 = 0x24;
+    pub const DMUL: u8 = 0x25;
+    pub const DDIV: u8 = 0x26;
+    pub const DNEG: u8 = 0x27;
+    pub const DPOW: u8 = 0x28;
+    pub const DMUL_ADD: u8 = 0x29;
+    pub const DMUL_SUB: u8 = 0x2A;
+    pub const DNMUL_ADD: u8 = 0x2B;
+    // 0x2C reserved
+
+    // === Bitwise (0x2D-0x33) ===
+    pub const AND: u8 = 0x2D;
+    pub const OR: u8 = 0x2E;
+    pub const XOR: u8 = 0x2F;
+    pub const NOT: u8 = 0x30;           // unary
+    pub const SHL: u8 = 0x31;
+    pub const SHR: u8 = 0x32;
+    pub const USHR: u8 = 0x33;
+
+    // === Comparisons (0x34-0x3F) — rA = (rA op rB) ===
+    pub const IEQ: u8 = 0x34;
+    pub const INE: u8 = 0x35;
+    pub const ILT: u8 = 0x36;
+    pub const ILE: u8 = 0x37;
+    pub const ULT: u8 = 0x38;
+    pub const FEQ: u8 = 0x39;
+    pub const FNE: u8 = 0x3A;
+    pub const FLT: u8 = 0x3B;
+    pub const FLE: u8 = 0x3C;
+    pub const DEQ: u8 = 0x3D;
+    pub const DLT: u8 = 0x3E;
+    pub const DLE: u8 = 0x3F;
+
+    // === Fused Compare+Branch (0x40-0x43) ===
+    pub const ILT_JUMP: u8 = 0x40;     // A, B, +trail: i16 offset. Does NOT clobber rA.
+    pub const FLT_JUMP: u8 = 0x41;     // A, B, +trail: i16 offset
+    pub const ILE_JUMP: u8 = 0x42;
+    pub const FLE_JUMP: u8 = 0x43;
+
+    // === Type Conversions (0x44-0x4E) — unary, in-place ===
+    pub const I32_TO_F32: u8 = 0x44;
+    pub const F32_TO_I32: u8 = 0x45;
+    pub const I32_TO_F64: u8 = 0x46;
+    pub const F64_TO_I32: u8 = 0x47;
+    pub const F32_TO_F64: u8 = 0x48;
+    pub const F64_TO_F32: u8 = 0x49;
+    pub const I32_TO_I8: u8 = 0x4A;
+    pub const I8_TO_I32: u8 = 0x4B;
+    pub const I64_TO_U32: u8 = 0x4C;
+    // 0x4D-0x4E reserved
+
+    // === Memory: basic (0x4F-0x59) ===
+    pub const LOAD8: u8 = 0x4F;         // A=dst, B=addr
+    pub const LOAD32: u8 = 0x50;        // A=dst, B=addr
+    pub const LOAD64: u8 = 0x51;        // A=dst, B=addr
+    pub const STORE8: u8 = 0x52;        // A=addr, B=src
+    pub const STORE32: u8 = 0x53;       // A=addr, B=src
+    pub const STORE64: u8 = 0x54;       // A=addr, B=src
+    pub const LOAD32_OFF: u8 = 0x55;    // A=dst, B=base, +trail: i16 offset
+    pub const LOAD64_OFF: u8 = 0x56;    // A=dst, B=base, +trail: i16 offset
+    pub const STORE8_OFF: u8 = 0x57;    // A=base, B=src, +trail: i16 offset
+    pub const STORE32_OFF: u8 = 0x58;   // A=base, B=src, +trail: i16 offset
+    pub const STORE64_OFF: u8 = 0x59;   // A=base, B=src, +trail: i16 offset
+
+    // 0x5A-0x5F reserved
+
+    // === Memory: offset-encoded (no trailing word) (0x60-0x7D) ===
+    // Load32 with fixed byte offsets
+    pub const LOAD32_OFF0: u8 = 0x60;   // A=dst, B=base; *(base+0)
+    pub const LOAD32_OFF4: u8 = 0x61;
+    pub const LOAD32_OFF8: u8 = 0x62;
+    pub const LOAD32_OFF12: u8 = 0x63;
+    pub const LOAD32_OFF16: u8 = 0x64;
+    pub const LOAD32_OFF20: u8 = 0x65;
+    pub const LOAD32_OFF24: u8 = 0x66;
+    pub const LOAD32_OFF28: u8 = 0x67;
+    pub const LOAD32_OFF32: u8 = 0x68;
+
+    // Store32 with fixed byte offsets
+    pub const STORE32_OFF0: u8 = 0x69;  // A=base, B=src
+    pub const STORE32_OFF4: u8 = 0x6A;
+    pub const STORE32_OFF8: u8 = 0x6B;
+    pub const STORE32_OFF12: u8 = 0x6C;
+    pub const STORE32_OFF16: u8 = 0x6D;
+    pub const STORE32_OFF20: u8 = 0x6E;
+    pub const STORE32_OFF24: u8 = 0x6F;
+    pub const STORE32_OFF28: u8 = 0x70;
+    pub const STORE32_OFF32: u8 = 0x71;
+
+    // Load64 with fixed byte offsets
+    pub const LOAD64_OFF0: u8 = 0x72;
+    pub const LOAD64_OFF8: u8 = 0x73;
+    pub const LOAD64_OFF16: u8 = 0x74;
+    pub const LOAD64_OFF24: u8 = 0x75;
+    pub const LOAD64_OFF32: u8 = 0x76;
+
+    // Store64 with fixed byte offsets
+    pub const STORE64_OFF0: u8 = 0x77;
+    pub const STORE64_OFF8: u8 = 0x78;
+    pub const STORE64_OFF16: u8 = 0x79;
+    pub const STORE64_OFF24: u8 = 0x7A;
+    pub const STORE64_OFF32: u8 = 0x7B;
+
+    // Fused slot access
+    pub const LOAD_SLOT32: u8 = 0x7C;   // A=dst, +trail: slot index
+    pub const STORE_SLOT32: u8 = 0x7D;  // A=src, +trail: slot index
+
+    // 0x7E-0x7F reserved
+
+    // === Calls (0x80-0x87) ===
+    pub const CALL: u8 = 0x80;          // A=arg_count, +trail: func_idx
+    pub const CALL_INDIRECT: u8 = 0x81; // A=func_reg, B=arg_count
+    pub const CALL_CLOSURE: u8 = 0x82;  // A=fat_ptr_reg, B=arg_count
+    pub const CALL_EXTERN: u8 = 0x83;   // A=arg_count, +trail: globals_offset
+    // 0x84-0x87 reserved
+
+    // === Stack Frame (0x88-0x8F) ===
+    pub const ALLOC_LOCALS: u8 = 0x88;  // +trail: size in slots
+    pub const SAVE_REGS: u8 = 0x89;     // +trail: slot; save all 16 regs
+    pub const RESTORE_REGS: u8 = 0x8A;  // +trail: slot; restore r1-r15 (not r0)
+    pub const MEM_COPY: u8 = 0x8B;      // A=dst, B=src, +trail: size
+    pub const MEM_ZERO: u8 = 0x8C;      // A=dst, +trail: size
+    pub const SPILL: u8 = 0x8D;         // A=reg, +trail: slot
+    pub const RELOAD: u8 = 0x8E;        // A=reg, +trail: slot
+    // 0x8F reserved
+
+    // === Debugging (0x90-0x93) ===
+    pub const PRINT_I32: u8 = 0x90;     // A=src
+    pub const PRINT_F32: u8 = 0x91;     // A=src
+    pub const ASSERT: u8 = 0x92;        // A=src
+    pub const PUTC: u8 = 0x93;          // A=src
+
+    // 0x94-0x9F reserved
+
+    // === Math Builtins: Unary f32 (0xA0-0xB4) — in-place ===
+    pub const SIN_F32: u8 = 0xA0;
+    pub const COS_F32: u8 = 0xA1;
+    pub const TAN_F32: u8 = 0xA2;
+    pub const ASIN_F32: u8 = 0xA3;
+    pub const ACOS_F32: u8 = 0xA4;
+    pub const ATAN_F32: u8 = 0xA5;
+    pub const SINH_F32: u8 = 0xA6;
+    pub const COSH_F32: u8 = 0xA7;
+    pub const TANH_F32: u8 = 0xA8;
+    pub const ASINH_F32: u8 = 0xA9;
+    pub const ACOSH_F32: u8 = 0xAA;
+    pub const ATANH_F32: u8 = 0xAB;
+    pub const LN_F32: u8 = 0xAC;
+    pub const EXP_F32: u8 = 0xAD;
+    pub const EXP2_F32: u8 = 0xAE;
+    pub const LOG10_F32: u8 = 0xAF;
+    pub const LOG2_F32: u8 = 0xB0;
+    pub const SQRT_F32: u8 = 0xB1;
+    pub const ABS_F32: u8 = 0xB2;
+    pub const FLOOR_F32: u8 = 0xB3;
+    pub const CEIL_F32: u8 = 0xB4;
+
+    // === Math Builtins: Unary f64 (0xB5-0xC9) ===
+    pub const SIN_F64: u8 = 0xB5;
+    pub const COS_F64: u8 = 0xB6;
+    pub const TAN_F64: u8 = 0xB7;
+    pub const ASIN_F64: u8 = 0xB8;
+    pub const ACOS_F64: u8 = 0xB9;
+    pub const ATAN_F64: u8 = 0xBA;
+    pub const SINH_F64: u8 = 0xBB;
+    pub const COSH_F64: u8 = 0xBC;
+    pub const TANH_F64: u8 = 0xBD;
+    pub const ASINH_F64: u8 = 0xBE;
+    pub const ACOSH_F64: u8 = 0xBF;
+    pub const ATANH_F64: u8 = 0xC0;
+    pub const LN_F64: u8 = 0xC1;
+    pub const EXP_F64: u8 = 0xC2;
+    pub const EXP2_F64: u8 = 0xC3;
+    pub const LOG10_F64: u8 = 0xC4;
+    pub const LOG2_F64: u8 = 0xC5;
+    pub const SQRT_F64: u8 = 0xC6;
+    pub const ABS_F64: u8 = 0xC7;
+    pub const FLOOR_F64: u8 = 0xC8;
+    pub const CEIL_F64: u8 = 0xC9;
+
+    // === Predicates (0xCA-0xCD) ===
+    pub const ISINF_F32: u8 = 0xCA;
+    pub const ISINF_F64: u8 = 0xCB;
+    pub const ISNAN_F32: u8 = 0xCC;
+    pub const ISNAN_F64: u8 = 0xCD;
+
+    // === Binary math (0xCE-0xD5) — destructive ===
+    pub const POW_F32: u8 = 0xCE;
+    pub const ATAN2_F32: u8 = 0xCF;
+    pub const MIN_F32: u8 = 0xD0;
+    pub const MAX_F32: u8 = 0xD1;
+    pub const POW_F64: u8 = 0xD2;
+    pub const ATAN2_F64: u8 = 0xD3;
+    pub const MIN_F64: u8 = 0xD4;
+    pub const MAX_F64: u8 = 0xD5;
+
+    // === SIMD f32x4 (0xD6-0xDA) — destructive ===
+    pub const F32X4_ADD: u8 = 0xD6;
+    pub const F32X4_SUB: u8 = 0xD7;
+    pub const F32X4_MUL: u8 = 0xD8;
+    pub const F32X4_DIV: u8 = 0xD9;
+    pub const F32X4_NEG: u8 = 0xDA;
+
+    // === Extended (0xDB-0xE1) ===
+    pub const MEM_EQ: u8 = 0xDB;        // A, B, +trail: size
+    pub const MEM_NE: u8 = 0xDC;        // A, B, +trail: size
+    pub const SLICE_EQ: u8 = 0xDD;      // A, B, +trail: elem_size
+    pub const SLICE_NE: u8 = 0xDE;      // A, B, +trail: elem_size
+    pub const SLICE_LOAD32: u8 = 0xDF;  // A=dst(slice), B=index
+    pub const SLICE_STORE32: u8 = 0xE0; // A=slice, B=index; value from trailing reg
+    pub const LOAD8_OFF: u8 = 0xE1;     // A=dst, B=base, +trail: offset
+
+    // 0xE2-0xFF reserved (30 slots)
+}
+
+/// Returns true if the given opcode tag has a trailing u16 data word.
+pub fn has_trailing_word(opcode: u8) -> bool {
+    matches!(
+        opcode,
+        tags::JUMP
+            | tags::JUMP_IF_ZERO
+            | tags::JUMP_IF_NOT_ZERO
+            | tags::LOAD_IMM
+            | tags::LOAD_IMM_WIDE
+            | tags::LOAD_F32
+            | tags::LOAD_F64
+            | tags::LOAD_CONST
+            | tags::LOCAL_ADDR
+            | tags::GLOBAL_ADDR
+            | tags::IADD_IMM
+            | tags::FMUL_ADD
+            | tags::FMUL_SUB
+            | tags::FNMUL_ADD
+            | tags::DMUL_ADD
+            | tags::DMUL_SUB
+            | tags::DNMUL_ADD
+            | tags::ILT_JUMP
+            | tags::FLT_JUMP
+            | tags::ILE_JUMP
+            | tags::FLE_JUMP
+            | tags::LOAD32_OFF
+            | tags::LOAD64_OFF
+            | tags::STORE8_OFF
+            | tags::STORE32_OFF
+            | tags::STORE64_OFF
+            | tags::LOAD_SLOT32
+            | tags::STORE_SLOT32
+            | tags::CALL
+            | tags::CALL_EXTERN
+            | tags::ALLOC_LOCALS
+            | tags::SAVE_REGS
+            | tags::RESTORE_REGS
+            | tags::MEM_COPY
+            | tags::MEM_ZERO
+            | tags::SPILL
+            | tags::RELOAD
+            | tags::MEM_EQ
+            | tags::MEM_NE
+            | tags::SLICE_EQ
+            | tags::SLICE_NE
+            | tags::LOAD8_OFF
+    )
+}
+
+/// Get the name of a 16-bit opcode tag for debug printing.
+pub fn tag_name(opcode: u8) -> &'static str {
+    match opcode {
+        tags::NOP => "Nop",
+        tags::HALT => "Halt",
+        tags::RETURN => "Return",
+        tags::RETURN_REG => "ReturnReg",
+        tags::JUMP => "Jump",
+        tags::JUMP_IF_ZERO => "JumpIfZero",
+        tags::JUMP_IF_NOT_ZERO => "JumpIfNotZero",
+        tags::MOVE => "Move",
+        tags::LOAD_IMM => "LoadImm",
+        tags::LOAD_IMM_WIDE => "LoadImmWide",
+        tags::LOAD_F32 => "LoadF32",
+        tags::LOAD_F64 => "LoadF64",
+        tags::LOAD_CONST => "LoadConst",
+        tags::LOCAL_ADDR => "LocalAddr",
+        tags::GLOBAL_ADDR => "GlobalAddr",
+        tags::GET_CLOSURE_PTR => "GetClosurePtr",
+        tags::IADD => "IAdd",
+        tags::ISUB => "ISub",
+        tags::IMUL => "IMul",
+        tags::IDIV => "IDiv",
+        tags::UDIV => "UDiv",
+        tags::IREM => "IRem",
+        tags::IPOW => "IPow",
+        tags::INEG => "INeg",
+        tags::IADD_IMM => "IAddImm",
+        tags::FADD => "FAdd",
+        tags::FSUB => "FSub",
+        tags::FMUL => "FMul",
+        tags::FDIV => "FDiv",
+        tags::FNEG => "FNeg",
+        tags::FPOW => "FPow",
+        tags::FMUL_ADD => "FMulAdd",
+        tags::FMUL_SUB => "FMulSub",
+        tags::FNMUL_ADD => "FNMulAdd",
+        tags::DADD => "DAdd",
+        tags::DSUB => "DSub",
+        tags::DMUL => "DMul",
+        tags::DDIV => "DDiv",
+        tags::DNEG => "DNeg",
+        tags::DPOW => "DPow",
+        tags::DMUL_ADD => "DMulAdd",
+        tags::DMUL_SUB => "DMulSub",
+        tags::DNMUL_ADD => "DNMulAdd",
+        tags::AND => "And",
+        tags::OR => "Or",
+        tags::XOR => "Xor",
+        tags::NOT => "Not",
+        tags::SHL => "Shl",
+        tags::SHR => "Shr",
+        tags::USHR => "UShr",
+        tags::IEQ => "IEq",
+        tags::INE => "INe",
+        tags::ILT => "ILt",
+        tags::ILE => "ILe",
+        tags::ULT => "ULt",
+        tags::FEQ => "FEq",
+        tags::FNE => "FNe",
+        tags::FLT => "FLt",
+        tags::FLE => "FLe",
+        tags::DEQ => "DEq",
+        tags::DLT => "DLt",
+        tags::DLE => "DLe",
+        tags::ILT_JUMP => "ILtJump",
+        tags::FLT_JUMP => "FLtJump",
+        tags::ILE_JUMP => "ILeJump",
+        tags::FLE_JUMP => "FLeJump",
+        tags::I32_TO_F32 => "I32ToF32",
+        tags::F32_TO_I32 => "F32ToI32",
+        tags::I32_TO_F64 => "I32ToF64",
+        tags::F64_TO_I32 => "F64ToI32",
+        tags::F32_TO_F64 => "F32ToF64",
+        tags::F64_TO_F32 => "F64ToF32",
+        tags::I32_TO_I8 => "I32ToI8",
+        tags::I8_TO_I32 => "I8ToI32",
+        tags::I64_TO_U32 => "I64ToU32",
+        tags::LOAD8 => "Load8",
+        tags::LOAD32 => "Load32",
+        tags::LOAD64 => "Load64",
+        tags::STORE8 => "Store8",
+        tags::STORE32 => "Store32",
+        tags::STORE64 => "Store64",
+        tags::LOAD32_OFF => "Load32Off",
+        tags::LOAD64_OFF => "Load64Off",
+        tags::STORE8_OFF => "Store8Off",
+        tags::STORE32_OFF => "Store32Off",
+        tags::STORE64_OFF => "Store64Off",
+        tags::LOAD32_OFF0 => "Load32Off0",
+        tags::LOAD32_OFF4 => "Load32Off4",
+        tags::LOAD32_OFF8 => "Load32Off8",
+        tags::LOAD32_OFF12 => "Load32Off12",
+        tags::LOAD32_OFF16 => "Load32Off16",
+        tags::LOAD32_OFF20 => "Load32Off20",
+        tags::LOAD32_OFF24 => "Load32Off24",
+        tags::LOAD32_OFF28 => "Load32Off28",
+        tags::LOAD32_OFF32 => "Load32Off32",
+        tags::STORE32_OFF0 => "Store32Off0",
+        tags::STORE32_OFF4 => "Store32Off4",
+        tags::STORE32_OFF8 => "Store32Off8",
+        tags::STORE32_OFF12 => "Store32Off12",
+        tags::STORE32_OFF16 => "Store32Off16",
+        tags::STORE32_OFF20 => "Store32Off20",
+        tags::STORE32_OFF24 => "Store32Off24",
+        tags::STORE32_OFF28 => "Store32Off28",
+        tags::STORE32_OFF32 => "Store32Off32",
+        tags::LOAD64_OFF0 => "Load64Off0",
+        tags::LOAD64_OFF8 => "Load64Off8",
+        tags::LOAD64_OFF16 => "Load64Off16",
+        tags::LOAD64_OFF24 => "Load64Off24",
+        tags::LOAD64_OFF32 => "Load64Off32",
+        tags::STORE64_OFF0 => "Store64Off0",
+        tags::STORE64_OFF8 => "Store64Off8",
+        tags::STORE64_OFF16 => "Store64Off16",
+        tags::STORE64_OFF24 => "Store64Off24",
+        tags::STORE64_OFF32 => "Store64Off32",
+        tags::LOAD_SLOT32 => "LoadSlot32",
+        tags::STORE_SLOT32 => "StoreSlot32",
+        tags::CALL => "Call",
+        tags::CALL_INDIRECT => "CallIndirect",
+        tags::CALL_CLOSURE => "CallClosure",
+        tags::CALL_EXTERN => "CallExtern",
+        tags::ALLOC_LOCALS => "AllocLocals",
+        tags::SAVE_REGS => "SaveRegs",
+        tags::RESTORE_REGS => "RestoreRegs",
+        tags::MEM_COPY => "MemCopy",
+        tags::MEM_ZERO => "MemZero",
+        tags::SPILL => "Spill",
+        tags::RELOAD => "Reload",
+        tags::PRINT_I32 => "PrintI32",
+        tags::PRINT_F32 => "PrintF32",
+        tags::ASSERT => "Assert",
+        tags::PUTC => "Putc",
+        tags::SIN_F32 => "SinF32",
+        tags::COS_F32 => "CosF32",
+        tags::TAN_F32 => "TanF32",
+        tags::ASIN_F32 => "AsinF32",
+        tags::ACOS_F32 => "AcosF32",
+        tags::ATAN_F32 => "AtanF32",
+        tags::SINH_F32 => "SinhF32",
+        tags::COSH_F32 => "CoshF32",
+        tags::TANH_F32 => "TanhF32",
+        tags::ASINH_F32 => "AsinhF32",
+        tags::ACOSH_F32 => "AcoshF32",
+        tags::ATANH_F32 => "AtanhF32",
+        tags::LN_F32 => "LnF32",
+        tags::EXP_F32 => "ExpF32",
+        tags::EXP2_F32 => "Exp2F32",
+        tags::LOG10_F32 => "Log10F32",
+        tags::LOG2_F32 => "Log2F32",
+        tags::SQRT_F32 => "SqrtF32",
+        tags::ABS_F32 => "AbsF32",
+        tags::FLOOR_F32 => "FloorF32",
+        tags::CEIL_F32 => "CeilF32",
+        tags::SIN_F64 => "SinF64",
+        tags::COS_F64 => "CosF64",
+        tags::TAN_F64 => "TanF64",
+        tags::ASIN_F64 => "AsinF64",
+        tags::ACOS_F64 => "AcosF64",
+        tags::ATAN_F64 => "AtanF64",
+        tags::SINH_F64 => "SinhF64",
+        tags::COSH_F64 => "CoshF64",
+        tags::TANH_F64 => "TanhF64",
+        tags::ASINH_F64 => "AsinhF64",
+        tags::ACOSH_F64 => "AcoshF64",
+        tags::ATANH_F64 => "AtanhF64",
+        tags::LN_F64 => "LnF64",
+        tags::EXP_F64 => "ExpF64",
+        tags::EXP2_F64 => "Exp2F64",
+        tags::LOG10_F64 => "Log10F64",
+        tags::LOG2_F64 => "Log2F64",
+        tags::SQRT_F64 => "SqrtF64",
+        tags::ABS_F64 => "AbsF64",
+        tags::FLOOR_F64 => "FloorF64",
+        tags::CEIL_F64 => "CeilF64",
+        tags::ISINF_F32 => "IsinfF32",
+        tags::ISINF_F64 => "IsinfF64",
+        tags::ISNAN_F32 => "IsnanF32",
+        tags::ISNAN_F64 => "IsnanF64",
+        tags::POW_F32 => "PowF32",
+        tags::ATAN2_F32 => "Atan2F32",
+        tags::MIN_F32 => "MinF32",
+        tags::MAX_F32 => "MaxF32",
+        tags::POW_F64 => "PowF64",
+        tags::ATAN2_F64 => "Atan2F64",
+        tags::MIN_F64 => "MinF64",
+        tags::MAX_F64 => "MaxF64",
+        tags::F32X4_ADD => "F32x4Add",
+        tags::F32X4_SUB => "F32x4Sub",
+        tags::F32X4_MUL => "F32x4Mul",
+        tags::F32X4_DIV => "F32x4Div",
+        tags::F32X4_NEG => "F32x4Neg",
+        tags::MEM_EQ => "MemEq",
+        tags::MEM_NE => "MemNe",
+        tags::SLICE_EQ => "SliceEq",
+        tags::SLICE_NE => "SliceNe",
+        tags::SLICE_LOAD32 => "SliceLoad32",
+        tags::SLICE_STORE32 => "SliceStore32",
+        tags::LOAD8_OFF => "Load8Off",
+        _ => "Unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_packed_op16_encode_decode() {
+        let op = PackedOp16::ab(tags::IADD, 3, 7);
+        assert_eq!(op.opcode(), tags::IADD);
+        assert_eq!(op.ra(), 3);
+        assert_eq!(op.rb(), 7);
+    }
+
+    #[test]
+    fn test_packed_op16_extremes() {
+        let op = PackedOp16::ab(0xFF, 15, 15);
+        assert_eq!(op.opcode(), 0xFF);
+        assert_eq!(op.ra(), 15);
+        assert_eq!(op.rb(), 15);
+
+        let op = PackedOp16::ab(0x00, 0, 0);
+        assert_eq!(op.opcode(), 0x00);
+        assert_eq!(op.ra(), 0);
+        assert_eq!(op.rb(), 0);
+    }
+
+    #[test]
+    fn test_a_only() {
+        let op = PackedOp16::a_only(tags::INEG, 5);
+        assert_eq!(op.opcode(), tags::INEG);
+        assert_eq!(op.ra(), 5);
+        assert_eq!(op.rb(), 0);
+    }
+
+    #[test]
+    fn test_trailing_word() {
+        assert!(has_trailing_word(tags::LOAD_IMM));
+        assert!(has_trailing_word(tags::JUMP));
+        assert!(has_trailing_word(tags::CALL));
+        assert!(!has_trailing_word(tags::IADD));
+        assert!(!has_trailing_word(tags::MOVE));
+        assert!(!has_trailing_word(tags::LOAD32_OFF0));
+    }
+
+    #[test]
+    fn test_no_duplicate_tags() {
+        // Verify all defined tag constants are unique.
+        let mut seen = std::collections::HashSet::new();
+        let all_tags = [
+            tags::NOP, tags::HALT, tags::RETURN, tags::RETURN_REG,
+            tags::JUMP, tags::JUMP_IF_ZERO, tags::JUMP_IF_NOT_ZERO,
+            tags::MOVE, tags::LOAD_IMM, tags::LOAD_IMM_WIDE,
+            tags::LOAD_F32, tags::LOAD_F64, tags::LOAD_CONST,
+            tags::LOCAL_ADDR, tags::GLOBAL_ADDR, tags::GET_CLOSURE_PTR,
+            tags::IADD, tags::ISUB, tags::IMUL, tags::IDIV,
+            tags::UDIV, tags::IREM, tags::IPOW, tags::INEG, tags::IADD_IMM,
+            tags::FADD, tags::FSUB, tags::FMUL, tags::FDIV,
+            tags::FNEG, tags::FPOW, tags::FMUL_ADD, tags::FMUL_SUB, tags::FNMUL_ADD,
+            tags::DADD, tags::DSUB, tags::DMUL, tags::DDIV,
+            tags::DNEG, tags::DPOW, tags::DMUL_ADD, tags::DMUL_SUB, tags::DNMUL_ADD,
+            tags::AND, tags::OR, tags::XOR, tags::NOT,
+            tags::SHL, tags::SHR, tags::USHR,
+            tags::IEQ, tags::INE, tags::ILT, tags::ILE, tags::ULT,
+            tags::FEQ, tags::FNE, tags::FLT, tags::FLE,
+            tags::DEQ, tags::DLT, tags::DLE,
+            tags::ILT_JUMP, tags::FLT_JUMP, tags::ILE_JUMP, tags::FLE_JUMP,
+            tags::I32_TO_F32, tags::F32_TO_I32, tags::I32_TO_F64, tags::F64_TO_I32,
+            tags::F32_TO_F64, tags::F64_TO_F32, tags::I32_TO_I8, tags::I8_TO_I32, tags::I64_TO_U32,
+            tags::LOAD8, tags::LOAD32, tags::LOAD64,
+            tags::STORE8, tags::STORE32, tags::STORE64,
+            tags::LOAD32_OFF, tags::LOAD64_OFF,
+            tags::STORE8_OFF, tags::STORE32_OFF, tags::STORE64_OFF,
+            tags::LOAD32_OFF0, tags::LOAD32_OFF4, tags::LOAD32_OFF8,
+            tags::LOAD32_OFF12, tags::LOAD32_OFF16, tags::LOAD32_OFF20,
+            tags::LOAD32_OFF24, tags::LOAD32_OFF28, tags::LOAD32_OFF32,
+            tags::STORE32_OFF0, tags::STORE32_OFF4, tags::STORE32_OFF8,
+            tags::STORE32_OFF12, tags::STORE32_OFF16, tags::STORE32_OFF20,
+            tags::STORE32_OFF24, tags::STORE32_OFF28, tags::STORE32_OFF32,
+            tags::LOAD64_OFF0, tags::LOAD64_OFF8, tags::LOAD64_OFF16,
+            tags::LOAD64_OFF24, tags::LOAD64_OFF32,
+            tags::STORE64_OFF0, tags::STORE64_OFF8, tags::STORE64_OFF16,
+            tags::STORE64_OFF24, tags::STORE64_OFF32,
+            tags::LOAD_SLOT32, tags::STORE_SLOT32,
+            tags::CALL, tags::CALL_INDIRECT, tags::CALL_CLOSURE, tags::CALL_EXTERN,
+            tags::ALLOC_LOCALS, tags::SAVE_REGS, tags::RESTORE_REGS,
+            tags::MEM_COPY, tags::MEM_ZERO, tags::SPILL, tags::RELOAD,
+            tags::PRINT_I32, tags::PRINT_F32, tags::ASSERT, tags::PUTC,
+            tags::SIN_F32, tags::COS_F32, tags::TAN_F32,
+            tags::ASIN_F32, tags::ACOS_F32, tags::ATAN_F32,
+            tags::SINH_F32, tags::COSH_F32, tags::TANH_F32,
+            tags::ASINH_F32, tags::ACOSH_F32, tags::ATANH_F32,
+            tags::LN_F32, tags::EXP_F32, tags::EXP2_F32,
+            tags::LOG10_F32, tags::LOG2_F32, tags::SQRT_F32,
+            tags::ABS_F32, tags::FLOOR_F32, tags::CEIL_F32,
+            tags::SIN_F64, tags::COS_F64, tags::TAN_F64,
+            tags::ASIN_F64, tags::ACOS_F64, tags::ATAN_F64,
+            tags::SINH_F64, tags::COSH_F64, tags::TANH_F64,
+            tags::ASINH_F64, tags::ACOSH_F64, tags::ATANH_F64,
+            tags::LN_F64, tags::EXP_F64, tags::EXP2_F64,
+            tags::LOG10_F64, tags::LOG2_F64, tags::SQRT_F64,
+            tags::ABS_F64, tags::FLOOR_F64, tags::CEIL_F64,
+            tags::ISINF_F32, tags::ISINF_F64, tags::ISNAN_F32, tags::ISNAN_F64,
+            tags::POW_F32, tags::ATAN2_F32, tags::MIN_F32, tags::MAX_F32,
+            tags::POW_F64, tags::ATAN2_F64, tags::MIN_F64, tags::MAX_F64,
+            tags::F32X4_ADD, tags::F32X4_SUB, tags::F32X4_MUL,
+            tags::F32X4_DIV, tags::F32X4_NEG,
+            tags::MEM_EQ, tags::MEM_NE, tags::SLICE_EQ, tags::SLICE_NE,
+            tags::SLICE_LOAD32, tags::SLICE_STORE32, tags::LOAD8_OFF,
+        ];
+        for &tag in &all_tags {
+            assert!(
+                seen.insert(tag),
+                "duplicate tag value: 0x{:02X} ({})",
+                tag,
+                tag_name(tag)
+            );
+        }
+    }
+}

--- a/src/vm_optimize.rs
+++ b/src/vm_optimize.rs
@@ -30,7 +30,7 @@ fn jump_targets(code: &[Opcode]) -> HashSet<usize> {
 }
 
 /// Find the number of virtual registers used in the code (max reg + 1).
-fn num_vregs(code: &[Opcode]) -> usize {
+pub fn num_vregs(code: &[Opcode]) -> usize {
     let mut max_r: Reg = 0;
     for op in code {
         if let Some(dst) = op.get_dst() {
@@ -49,6 +49,15 @@ pub fn optimize(code: &mut Vec<Opcode>, param_count: u8) -> Option<(u8, Vec<Reg>
     if code.is_empty() {
         return None;
     }
+    optimize_peephole(code);
+    // Register allocation: compact register numbering via linear scan
+    let (count, mapping) = register_allocation(code, param_count);
+    Some((count, mapping))
+}
+
+/// Run peephole optimization and instruction fusion passes without register allocation.
+/// Used by the 16-bit VM backend which has its own register allocator.
+pub fn optimize_peephole(code: &mut Vec<Opcode>) {
     // Run optimization passes iteratively until no more changes.
     for _ in 0..3 {
         move_forwarding(code);
@@ -64,9 +73,6 @@ pub fn optimize(code: &mut Vec<Opcode>, param_count: u8) -> Option<(u8, Vec<Reg>
     fuse_multiply_add(code);
     // Fuse compare+branch into single instructions
     fuse_compare_branch(code);
-    // Register allocation: compact register numbering via linear scan
-    let (count, mapping) = register_allocation(code, param_count);
-    Some((count, mapping))
 }
 
 /// Dead code elimination: NOP any instruction that writes to a register
@@ -652,7 +658,7 @@ fn fuse_compare_branch(code: &mut Vec<Opcode>) {
 
 /// Compute live ranges for all virtual registers.
 /// Returns (def_point, last_use, is_used) vectors indexed by register number.
-fn compute_live_ranges(code: &[Opcode]) -> (Vec<u32>, Vec<u32>, Vec<bool>) {
+pub fn compute_live_ranges(code: &[Opcode]) -> (Vec<u32>, Vec<u32>, Vec<bool>) {
     let n = num_vregs(code);
     let mut def_point = vec![u32::MAX; n];
     let mut last_use = vec![0u32; n];
@@ -731,7 +737,7 @@ fn compute_live_ranges(code: &[Opcode]) -> (Vec<u32>, Vec<u32>, Vec<bool>) {
 /// Copy coalescing: merge virtual registers connected by Move instructions
 /// when their live ranges don't interfere. This eliminates moves and reduces
 /// register pressure. Runs as a pre-pass before linear scan allocation.
-fn copy_coalesce(code: &mut [Opcode], param_count: u8) {
+pub fn copy_coalesce(code: &mut [Opcode], param_count: u8) {
     let n = num_vregs(code);
     // Union-find for register coalescing.
     let mut parent: Vec<Reg> = (0..n as Reg).collect();


### PR DESCRIPTION
Corrections and additions based on practical experience writing Lyte in Audulus, including things discovered through iterative use of lyte-cli --check. Covers Audulus-specific patterns, Do's and Don'ts, and common pitfalls not covered in the existing docs.