### PR TITLE
Add f64 Biquad benchmark

### DIFF
--- a/benchmark/biquad_f64.lyte
+++ b/benchmark/biquad_f64.lyte
@@ -1,0 +1,70 @@
+// Biquad filter DSP benchmark
+// Process 10 million samples through a lowpass filter
+// Double-precision version using f32 literals cast to f64.
+
+struct Biquad {
+    b0: f64, b1: f64, b2: f64,
+    a1: f64, a2: f64,
+    x1: f64, x2: f64,
+    y1: f64, y2: f64
+}
+
+// Design a 2nd-order lowpass (RBJ cookbook)
+lpf(fc: f64, fs: f64, q: f64) -> Biquad {
+    var w0 = (2.0 as f64) * (3.14159265 as f64) * fc / fs
+    var alpha = sin(w0) / ((2.0 as f64) * q)
+    var cs = cos(w0)
+
+    var a0 = (1.0 as f64) + alpha
+    var inv = (1.0 as f64) / a0
+
+    var bq: Biquad
+    bq.b1 = ((1.0 as f64) - cs) * inv
+    bq.b0 = bq.b1 / (2.0 as f64)
+    bq.b2 = bq.b0
+    bq.a1 = ((0.0 as f64) - (2.0 as f64) * cs) * inv
+    bq.a2 = ((1.0 as f64) - alpha) * inv
+    bq.x1 = 0.0 as f64
+    bq.x2 = 0.0 as f64
+    bq.y1 = 0.0 as f64
+    bq.y2 = 0.0 as f64
+    return bq
+}
+
+main {
+    var bq = lpf(1000.0 as f64, 44100.0 as f64, 0.707 as f64)
+    var b0 = bq.b0
+    var b1 = bq.b1
+    var b2 = bq.b2
+    var a1 = bq.a1
+    var a2 = bq.a2
+    var x1 = bq.x1
+    var x2 = bq.x2
+    var y1 = bq.y1
+    var y2 = bq.y2
+
+    var n = 10000000
+    var phase = 0.0 as f64
+    var freq = (440.0 as f64) / (44100.0 as f64)
+    var last_y = 0.0 as f64
+    var two_pi = (2.0 as f64) * (3.14159265 as f64)
+
+    // Process a 440 Hz sine wave through the filter
+    for i in 0 .. n {
+        var x = sin(phase * two_pi)
+        phase = phase + freq
+        if phase > (1.0 as f64) { phase = phase - (1.0 as f64) }
+
+        var y = b0 * x + b1 * x1 + b2 * x2 - a1 * y1 - a2 * y2
+        x2 = x1
+        x1 = x
+        y2 = y1
+        y1 = y
+        last_y = y
+    }
+
+    // Use last_y so the optimizer can't eliminate the loop.
+    print(last_y as i32)
+    print(n)
+    println(" samples processed")
+}

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -103,8 +103,16 @@ run_benchmark() {
     local C_O2_TIME C_O3_TIME LYTE_JIT LYTE_VM LYTE_ASM LYTE_STACK LYTE_LLVM LUA LUAJIT_JIT LUAJIT_INT
 
     echo "Running benchmarks..."
-    C_O2_TIME=$(avg "C -O2 ($NAME)" "$C_O2")
-    C_O3_TIME=$(avg "C -O3 ($NAME)" "$C_O3")
+    if [ -n "$C_O2" ]; then
+        C_O2_TIME=$(avg "C -O2 ($NAME)" "$C_O2")
+    else
+        C_O2_TIME=""
+    fi
+    if [ -n "$C_O3" ]; then
+        C_O3_TIME=$(avg "C -O3 ($NAME)" "$C_O3")
+    else
+        C_O3_TIME=""
+    fi
     LYTE_JIT=$(avg "Lyte Cranelift ($NAME)" "$LYTE --backend jit $LYTE_FILE --timing 2>&1 | grep 'jit exec:'")
     LYTE_VM=$(avg "Lyte VM ($NAME)" "$LYTE --backend vm $LYTE_FILE --timing 2>&1 | grep 'vm exec:'")
     if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
@@ -147,6 +155,13 @@ run_benchmark "Biquad" \
     "benchmark/biquad_c_o3" \
     "benchmark/biquad.lua" \
     "10M samples through a 1kHz lowpass"
+
+run_benchmark "Biquad f64" \
+    "benchmark/biquad_f64.lyte" \
+    "" \
+    "" \
+    "benchmark/biquad.lua" \
+    "10M samples through a 1kHz lowpass, double precision"
 
 run_benchmark "Sort" \
     "benchmark/sort.lyte" \


### PR DESCRIPTION
Adds a 64-bit Lyte Biquad benchmark.

Changes:
- Added `benchmark/biquad_f64.lyte`
- Updated `benchmark/run.sh`
  - Include `Biquad f64`
  - Made `C_O2` and `C_O3` benchmark runner arguments optional so Lyte-only benchmarks can run without C baselines

Validation:
- `cargo test --workspace`
- `./benchmark/run.sh 1`