### PR TITLE
Allow semicolons to separate statements

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -853,7 +853,9 @@ fn parse_block(arena: &mut ExprArena, typevars: &[Name], cx: &mut ParseContext) 
 
         r.push(parse_stmt(arena, typevars, cx));
 
-        if cx.lex.tok != Token::Endl {
+        // Statements are separated by newlines or semicolons. Semicolons let
+        // multiple statements share a line.
+        if cx.lex.tok != Token::Endl && cx.lex.tok != Token::Semi {
             break;
         }
 
@@ -1461,6 +1463,12 @@ mod tests {
                 "{ x = y\n z = w }",
                 "{ f(x)\n g(y) }",
                 "{ var x = y\n var z = w }",
+                "{ x; y }",
+                "{ x; }",
+                "{ x;\n y }",
+                "{ x = y; z = w }",
+                "{ var x = y; var z = w; f(x) }",
+                "{ while x { y; z }; w }",
             ],
         );
     }

--- a/tests/cases/semicolons.lyte
+++ b/tests/cases/semicolons.lyte
@@ -1,0 +1,25 @@
+// expected stdout:
+// compilation successful
+// assert(true)
+// assert(true)
+// assert(true)
+// assert(true)
+
+sum_three(a: i32, b: i32, c: i32) -> i32 {
+    var t = 0; t = t + a; t = t + b
+    t = t + c
+    return t
+}
+
+main {
+    var x = 1; var y = 2; var z = x + y
+    assert(z == 3)
+
+    // Trailing semicolon before the closing brace.
+    assert(sum_three(1, 2, 3) == 6);
+
+    var i = 0
+    while i < 3 { i = i + 1; x = x + i }
+    assert(i == 3)
+    assert(x == 7)
+}


### PR DESCRIPTION
Statements in a block could only be separated by newlines. This accepts `;` as an alternate separator so multiple statements can share a line.

```
main {
    var x = 1; var y = 2; var z = x + y
    while i < 3 { i = i + 1; x = x + i }
}
```

## Implementation

One change in `parse_block` (`src/parser.rs`): the loop now continues on `Token::Semi` as well as `Token::Endl`.

The lexer already produced `Token::Semi` — it was used only for array types (`[T; N]`) and array repeat literals (`[x; n]`). Those are distinct contexts and are unaffected. A `;` is now accepted anywhere a newline was accepted as a separator, including a trailing one before `}`. Since `parse_block` is shared, this covers function bodies, `while`/`for` bodies, `if`/`else` branches, and block expressions.

Semantics are otherwise unchanged: the semicolon is purely a separator, so unlike Rust a trailing one does **not** void the block's value — `{ a; b; }` still evaluates to `b`, exactly like `{ a\n b\n }`.

## Tests

- `tests/cases/semicolons.lyte` — new golden test: multiple statements per line, trailing `;`, a one-line `while` body, and semicolons inside a value-returning function. Verified on both the JIT and VM backends.
- `test_parse_block` in `src/parser.rs` — added `{ x; y }`, `{ x; }`, `{ x;\n y }`, `{ x = y; z = w }`, `{ var x = y; var z = w; f(x) }`, `{ while x { y; z }; w }`.

`cargo test --workspace`: 351 + 4 + 21 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QL98e281ffpSW7JKQyS87C