### PR TITLE
Check lambda bodies in the safety checker

### DIFF
--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -110,6 +110,10 @@ struct Var {
 /// - Only tracks `+`, `-`, and `*` for arithmetic
 /// - Constraints from while loop conditions don't persist after mutation
 /// - Complex expressions may result in unconstrained intervals
+/// - A lambda body is checked with its parameters unconstrained, the same way
+///   a function body is, unless the lambda is called directly (`(|i| ..)(5)`),
+///   in which case the argument intervals are used. A lambda stored in a
+///   variable and called later must therefore guard its own parameters.
 pub struct SafetyChecker {
     /// Currently declared vars, as we're checking.
     vars: Vec<Var>,
@@ -172,6 +176,18 @@ impl SafetyChecker {
                 non_zero: true,
             });
         }
+    }
+
+    /// Drop everything we know about `name`. Used when a lambda parameter
+    /// shadows a captured variable of the same name.
+    fn forget(&mut self, name: Name) {
+        self.constraints.retain(|c| c.name != name);
+        self.len_bounds
+            .retain(|b| b.index != name && b.array != name);
+        self.leq_len_bounds
+            .retain(|b| b.index != name && b.array != name);
+        self.min_len_bounds.retain(|b| b.array != name);
+        self.var_bounds.retain(|b| b.lo != name && b.hi != name);
     }
 
     fn find(&self, name: Name) -> Option<IndexConstraint> {
@@ -890,8 +906,22 @@ impl SafetyChecker {
                 IndexInterval::default()
             }
             Expr::Call(callee_expr, args) => {
-                for arg in args {
-                    self.check_expr(*arg, decl, decls);
+                let arg_ivals: Vec<_> = args
+                    .iter()
+                    .map(|arg| self.check_expr(*arg, decl, decls))
+                    .collect();
+                // An immediately-invoked lambda has known arguments, so check
+                // its body against them rather than unconstrained.
+                if let Expr::Lambda { params, body } = &decl.arena[*callee_expr] {
+                    let (params, body) = (params.clone(), *body);
+                    self.check_lambda_body(
+                        *callee_expr,
+                        &params,
+                        body,
+                        Some((args, &arg_ivals)),
+                        decl,
+                        decls,
+                    );
                 }
                 self.check_call_requires(*callee_expr, args, expr, decl, decls);
                 IndexInterval::default()
@@ -1058,8 +1088,109 @@ impl SafetyChecker {
                 }
                 IndexInterval::default()
             }
+            Expr::Lambda { params, body } => {
+                // Nothing is known about the arguments at the definition site,
+                // so the body is checked with its parameters unconstrained.
+                // (A directly-called lambda is handled by the `Call` arm, which
+                // knows the arguments.)
+                self.check_lambda_body(expr, &params.clone(), *body, None, decl, decls);
+                IndexInterval::default()
+            }
             _ => IndexInterval::default(),
         }
+    }
+
+    /// Check a lambda body. Parameters shadow any captured variable of the
+    /// same name; `call_args` supplies the argument intervals (and the
+    /// argument expressions, for symbolic length bounds) when the lambda is
+    /// called directly at a known call site, and is `None` at the definition
+    /// site, where the arguments are unknown.
+    fn check_lambda_body(
+        &mut self,
+        lambda_expr: ExprID,
+        params: &[Param],
+        body: ExprID,
+        call_args: Option<(&[ExprID], &[IndexInterval])>,
+        decl: &FuncDecl,
+        decls: &DeclTable,
+    ) {
+        let saved_vars = self.vars.clone();
+        let saved_constraints = self.constraints.clone();
+        let saved_len_bounds = self.len_bounds.clone();
+        let saved_leq_len_bounds = self.leq_len_bounds.clone();
+        let saved_min_len_bounds = self.min_len_bounds.clone();
+        let saved_var_bounds = self.var_bounds.clone();
+
+        // Lambda params are usually unannotated, so recover their types from
+        // the solved function type of the lambda expression.
+        let solved_param_tys = if lambda_expr < decl.types.len() {
+            match &*decl.types[lambda_expr] {
+                Type::Func(dom, _) => match &**dom {
+                    Type::Tuple(tys) => tys.clone(),
+                    _ => vec![*dom],
+                },
+                _ => vec![],
+            }
+        } else {
+            vec![]
+        };
+
+        for (i, param) in params.iter().enumerate() {
+            let ty = param.ty.or_else(|| solved_param_tys.get(i).copied());
+            let is_u32 = ty == Some(mk_type(Type::UInt32));
+
+            // The param shadows any captured variable of the same name.
+            self.forget(param.name);
+            self.vars.push(Var {
+                name: param.name,
+                ty: ty.unwrap_or_else(|| mk_type(Type::Void)),
+            });
+
+            let arg = call_args.and_then(|(exprs, ivals)| Some((exprs.get(i)?, ivals.get(i)?)));
+            match arg {
+                Some((arg_expr, ival)) => {
+                    let mut min = (ival.min != i64::MIN).then_some(ival.min);
+                    let max = (ival.max != i64::MAX).then_some(ival.max);
+                    if is_u32 {
+                        min = Some(min.unwrap_or(0).max(0));
+                    }
+                    self.add(param.name, min, max);
+                    if ival.non_zero {
+                        self.add_non_zero(param.name);
+                    }
+                    // The param inherits the argument's symbolic length bounds.
+                    if let Expr::Id(arg_name) = &decl.arena[*arg_expr] {
+                        let inherited: Vec<_> = saved_len_bounds
+                            .iter()
+                            .filter(|b| b.index == *arg_name)
+                            .map(|b| b.array)
+                            .collect();
+                        for array in inherited {
+                            self.len_bounds.push(LenBound {
+                                index: param.name,
+                                array,
+                            });
+                        }
+                    }
+                }
+                None if is_u32 => self.add(param.name, Some(0), None),
+                None => self.add(param.name, None, None),
+            }
+        }
+
+        self.check_expr(body, decl, decls);
+
+        self.vars = saved_vars;
+        self.constraints = saved_constraints;
+        self.len_bounds = saved_len_bounds;
+        self.leq_len_bounds = saved_leq_len_bounds;
+        self.min_len_bounds = saved_min_len_bounds;
+        self.var_bounds = saved_var_bounds;
+
+        // Assignments in the body take effect whenever the lambda is called,
+        // which we can't pin down, so conservatively drop what we knew about
+        // the variables it writes to.
+        self.invalidate_assigned(body, &decl.arena);
     }
 
     /// Check if every assignment to `var_name` in the expression tree is of the
@@ -2864,5 +2995,170 @@ mod tests {
         ";
         let errors = check(s);
         assert!(errors.is_empty());
+    }
+
+    #[test]
+    pub fn test_lambda_index_unconstrained() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var g = (|i: i32| a[i])
+        }
+        ";
+
+        let errors = check(s);
+        // Nothing is known about i at the definition site.
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    pub fn test_lambda_index_guarded() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var g = (|i| if i >= 0 && i < 100 { a[i] } else { 0 })
+        }
+        ";
+
+        let errors = check(s);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    pub fn test_lambda_assign_index_unconstrained() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var g = (|i: i32| a[i] = 7)
+        }
+        ";
+
+        let errors = check(s);
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    pub fn test_lambda_div_by_param() {
+        let s = "
+        f() {
+            var g = (|d| 100 / d)
+        }
+        ";
+
+        let errors = check(s);
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    pub fn test_lambda_div_guarded() {
+        let s = "
+        f() {
+            var g = (|d| if d != 0 { 100 / d } else { 0 })
+        }
+        ";
+
+        let errors = check(s);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    pub fn test_lambda_captures_constraint() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            let i = 5
+            var g = (| | a[i])
+        }
+        ";
+
+        let errors = check(s);
+        // The captured i keeps the interval it has at the definition site.
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    pub fn test_lambda_param_shadows_capture() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            let i = 5
+            var g = (|i: i32| a[i])
+        }
+        ";
+
+        let errors = check(s);
+        // The param shadows the captured i, so its bounds don't apply.
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    pub fn test_lambda_immediate_call_safe_arg() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            let x = (|i| a[i])(5)
+        }
+        ";
+
+        let errors = check(s);
+        // A direct call gives the param a known interval.
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    pub fn test_lambda_immediate_call_unsafe_arg() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            let x = (|i| a[i])(1000)
+        }
+        ";
+
+        let errors = check(s);
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    pub fn test_lambda_nested_unconstrained() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var g = (|i: i32| (|j| a[j])(i))
+        }
+        ";
+
+        let errors = check(s);
+        // The inner lambda is called with the outer's unconstrained param.
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    pub fn test_lambda_body_assignment_invalidates_capture() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var i = 5
+            var g = (| | i = 1000)
+            a[i]
+        }
+        ";
+
+        let errors = check(s);
+        // Calling g could have changed i, so its interval no longer holds.
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    pub fn test_lambda_u32_param_non_negative() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var g = (|i: u32| a[i])
+        }
+        ";
+
+        let errors = check(s);
+        // u32 is known to be >= 0, so only the upper bound is unproven.
+        assert_eq!(errors.len(), 1);
     }
 }

--- a/src/safety_checker.rs
+++ b/src/safety_checker.rs
@@ -114,6 +114,12 @@ struct Var {
 ///   a function body is, unless the lambda is called directly (`(|i| ..)(5)`),
 ///   in which case the argument intervals are used. A lambda stored in a
 ///   variable and called later must therefore guard its own parameters.
+/// - Captured variables keep their definition-site constraints only if the
+///   enclosing function never assigns to them, since the call happens at an
+///   unknown later time. A captured variable that is assigned anywhere in the
+///   function — including inside the lambda itself — is unconstrained in the
+///   body, so the body has to guard it too. A directly-called lambda is
+///   exempt: its definition site is its call site.
 pub struct SafetyChecker {
     /// Currently declared vars, as we're checking.
     vars: Vec<Var>,
@@ -133,6 +139,12 @@ pub struct SafetyChecker {
     /// Variable-to-variable less-than bounds: records that `lo < hi`.
     var_bounds: Vec<VarBound>,
 
+    /// Every variable assigned anywhere in the function currently being
+    /// checked. A lambda body can run at any point after its definition, so
+    /// anything in here is unconstrained inside a lambda that isn't called
+    /// immediately.
+    fn_assigned: Vec<Name>,
+
     pub errors: Vec<SafetyError>,
 }
 
@@ -145,8 +157,25 @@ impl SafetyChecker {
             leq_len_bounds: vec![],
             min_len_bounds: vec![],
             var_bounds: vec![],
+            fn_assigned: vec![],
             errors: vec![],
         }
+    }
+
+    /// Record a safety error, dropping exact duplicates. `match_expr` visits
+    /// some subexpressions more than once (e.g. the `Greater` arm looks at its
+    /// rhs both as a general expression and as an `array.len > N` pattern), and
+    /// since `check_expr` descends into lambda bodies that would otherwise
+    /// surface as the same diagnostic reported twice at one location.
+    fn push_error(&mut self, err: SafetyError) {
+        if self
+            .errors
+            .iter()
+            .any(|e| e.location == err.location && e.message == err.message)
+        {
+            return;
+        }
+        self.errors.push(err);
     }
 
     fn add(&mut self, name: Name, min: Option<i64>, max: Option<i64>) {
@@ -684,7 +713,7 @@ impl SafetyChecker {
                 let rhs_r = self.check_expr(*index_expr, decl, decls);
 
                 if rhs_r.min < 0 {
-                    self.errors.push(SafetyError {
+                    self.push_error(SafetyError {
                         location: decl.arena.locs[expr],
                         message: format!("couldn't prove index is >= 0"),
                     });
@@ -714,7 +743,7 @@ impl SafetyChecker {
                             _ => false,
                         };
                         if !interval_ok && !len_bound_ok {
-                            self.errors.push(SafetyError {
+                            self.push_error(SafetyError {
                                 location: decl.arena.locs[expr],
                                 message: format!("couldn't prove index is less than array length"),
                             });
@@ -750,7 +779,7 @@ impl SafetyChecker {
                             false
                         };
                         if !has_len_bound && !has_var_bound {
-                            self.errors.push(SafetyError {
+                            self.push_error(SafetyError {
                                 location: decl.arena.locs[expr],
                                 message: format!("couldn't prove index is less than array length"),
                             });
@@ -786,7 +815,7 @@ impl SafetyChecker {
                         false
                     };
                     if !has_len_bound && !has_min_len_bound {
-                        self.errors.push(SafetyError {
+                        self.push_error(SafetyError {
                             location: decl.arena.locs[expr],
                             message: format!("couldn't prove index is less than slice length"),
                         });
@@ -846,7 +875,7 @@ impl SafetyChecker {
                         let is_int =
                             matches!(*ty, Type::Int32 | Type::UInt32 | Type::Int8 | Type::UInt8);
                         if is_int && !rhs_range.excludes_zero() {
-                            self.errors.push(SafetyError {
+                            self.push_error(SafetyError {
                                 location: decl.arena.locs[expr],
                                 message: format!("couldn't prove divisor is non-zero"),
                             });
@@ -1096,6 +1125,22 @@ impl SafetyChecker {
                 self.check_lambda_body(expr, &params.clone(), *body, None, decl, decls);
                 IndexInterval::default()
             }
+            Expr::Tuple(exprs) => {
+                for e in exprs {
+                    self.check_expr(*e, decl, decls);
+                }
+                IndexInterval::default()
+            }
+            Expr::StructLit(_, fields) => {
+                for (_, e) in fields {
+                    self.check_expr(*e, decl, decls);
+                }
+                IndexInterval::default()
+            }
+            Expr::AsTy(e, _) | Expr::Arena(e) => {
+                self.check_expr(*e, decl, decls);
+                IndexInterval::default()
+            }
             _ => IndexInterval::default(),
         }
     }
@@ -1135,6 +1180,18 @@ impl SafetyChecker {
             vec![]
         };
 
+        // A lambda that isn't invoked right here runs at some unknown later
+        // point, so any capture the enclosing function assigns to — before or
+        // after the definition, including from inside this body — may hold a
+        // different value by then. Drop what we know about those. An
+        // immediately-invoked lambda is exempt: the definition site *is* the
+        // call site, so the current state is exact.
+        if call_args.is_none() {
+            for name in self.fn_assigned.clone() {
+                self.forget(name);
+            }
+        }
+
         for (i, param) in params.iter().enumerate() {
             let ty = param.ty.or_else(|| solved_param_tys.get(i).copied());
             let is_u32 = ty == Some(mk_type(Type::UInt32));
@@ -1159,8 +1216,13 @@ impl SafetyChecker {
                         self.add_non_zero(param.name);
                     }
                     // The param inherits the argument's symbolic length bounds.
+                    // Read these from the live state, not the entry snapshot:
+                    // `forget` above has already stripped bounds naming an
+                    // array that this param shadows, and bounds pushed for an
+                    // earlier param should propagate.
                     if let Expr::Id(arg_name) = &decl.arena[*arg_expr] {
-                        let inherited: Vec<_> = saved_len_bounds
+                        let inherited: Vec<_> = self
+                            .len_bounds
                             .iter()
                             .filter(|b| b.index == *arg_name)
                             .map(|b| b.array)
@@ -1196,74 +1258,45 @@ impl SafetyChecker {
     /// Check if every assignment to `var_name` in the expression tree is of the
     /// form `var_name = var_name + 1` (monotonic increment by 1). Returns false
     /// if the variable is assigned in any other way.
+    ///
+    /// Walks the whole tree, like `collect_assigned_vars`: the two have to
+    /// agree about where an assignment can hide, or the loop-exit min bound
+    /// gets handed back on the strength of an increment that isn't the only
+    /// write.
     fn is_monotonic_increment(var_name: Name, expr: ExprID, arena: &ExprArena) -> bool {
-        match &arena[expr] {
-            Expr::Binop(Binop::Assign, lhs, rhs) => {
-                if let Expr::Id(name) = &arena[*lhs] {
-                    if *name == var_name {
-                        // Check rhs is `var_name + 1`
-                        if let Expr::Binop(Binop::Plus, plus_lhs, plus_rhs) = &arena[*rhs] {
-                            let lhs_is_var =
-                                matches!(&arena[*plus_lhs], Expr::Id(n) if *n == var_name);
-                            let rhs_is_one = matches!(&arena[*plus_rhs], Expr::Int(1, _));
-                            return lhs_is_var && rhs_is_one;
-                        }
-                        return false; // Some other assignment to var_name
+        if let Expr::Binop(Binop::Assign, lhs, rhs) = &arena[expr] {
+            if let Expr::Id(name) = &arena[*lhs] {
+                if *name == var_name {
+                    // Check rhs is `var_name + 1`
+                    if let Expr::Binop(Binop::Plus, plus_lhs, plus_rhs) = &arena[*rhs] {
+                        let lhs_is_var = matches!(&arena[*plus_lhs], Expr::Id(n) if *n == var_name);
+                        let rhs_is_one = matches!(&arena[*plus_rhs], Expr::Int(1, _));
+                        return lhs_is_var && rhs_is_one;
                     }
+                    return false; // Some other assignment to var_name
                 }
-                // Assignment to a different variable — recurse into RHS
-                Self::is_monotonic_increment(var_name, *rhs, arena)
             }
-            Expr::Block(exprs) => exprs
-                .iter()
-                .all(|e| Self::is_monotonic_increment(var_name, *e, arena)),
-            Expr::If(cond, then_expr, else_expr) => {
-                Self::is_monotonic_increment(var_name, *cond, arena)
-                    && Self::is_monotonic_increment(var_name, *then_expr, arena)
-                    && else_expr.map_or(true, |e| Self::is_monotonic_increment(var_name, e, arena))
-            }
-            Expr::While(cond, body) => {
-                Self::is_monotonic_increment(var_name, *cond, arena)
-                    && Self::is_monotonic_increment(var_name, *body, arena)
-            }
-            Expr::For { body, .. } => Self::is_monotonic_increment(var_name, *body, arena),
-            _ => true, // No assignment here
         }
+        arena[expr]
+            .subexprs()
+            .iter()
+            .all(|child| Self::is_monotonic_increment(var_name, *child, arena))
     }
 
-    /// Collect all variable names that are assigned (via `=`) inside an expression tree.
+    /// Collect all variable names that are assigned (via `=`) inside an
+    /// expression tree.
+    ///
+    /// Walks every subexpression, including lambda bodies, initializers and
+    /// call arguments — an assignment nested in any of those still happens, and
+    /// missing one would leave a stale constraint in place.
     fn collect_assigned_vars(expr: ExprID, arena: &ExprArena, out: &mut Vec<Name>) {
-        match &arena[expr] {
-            Expr::Binop(Binop::Assign, lhs, rhs) => {
-                if let Expr::Id(name) = &arena[*lhs] {
-                    out.push(*name);
-                }
-                Self::collect_assigned_vars(*rhs, arena, out);
+        if let Expr::Binop(Binop::Assign, lhs, _) = &arena[expr] {
+            if let Expr::Id(name) = &arena[*lhs] {
+                out.push(*name);
             }
-            Expr::Binop(_, lhs, rhs) => {
-                Self::collect_assigned_vars(*lhs, arena, out);
-                Self::collect_assigned_vars(*rhs, arena, out);
-            }
-            Expr::Block(exprs) => {
-                for e in exprs {
-                    Self::collect_assigned_vars(*e, arena, out);
-                }
-            }
-            Expr::If(cond, then_expr, else_expr) => {
-                Self::collect_assigned_vars(*cond, arena, out);
-                Self::collect_assigned_vars(*then_expr, arena, out);
-                if let Some(e) = else_expr {
-                    Self::collect_assigned_vars(*e, arena, out);
-                }
-            }
-            Expr::While(cond, body) => {
-                Self::collect_assigned_vars(*cond, arena, out);
-                Self::collect_assigned_vars(*body, arena, out);
-            }
-            Expr::For { body, .. } => {
-                Self::collect_assigned_vars(*body, arena, out);
-            }
-            _ => {}
+        }
+        for child in arena[expr].subexprs() {
+            Self::collect_assigned_vars(child, arena, out);
         }
     }
 
@@ -1384,7 +1417,7 @@ impl SafetyChecker {
                     callee.arena.exprs[req].pretty_print(&callee.arena, 0),
                     *callee.name
                 );
-                self.errors.push(SafetyError {
+                self.push_error(SafetyError {
                     location: caller.arena.locs[call_expr],
                     message: msg,
                 });
@@ -1566,6 +1599,11 @@ impl SafetyChecker {
                 self.propagate_len_bounds();
             }
 
+            // Lambda bodies are checked against this to decide which captures
+            // are still trustworthy, so it has to cover the whole function.
+            self.fn_assigned.clear();
+            Self::collect_assigned_vars(body, &func_decl.arena, &mut self.fn_assigned);
+
             self.check_expr(body, &func_decl, decls);
 
             self.vars.clear();
@@ -1574,6 +1612,7 @@ impl SafetyChecker {
             self.leq_len_bounds.clear();
             self.min_len_bounds.clear();
             self.var_bounds.clear();
+            self.fn_assigned.clear();
         }
     }
 
@@ -1909,7 +1948,7 @@ impl SafetyChecker {
 
             if scc.len() == 1 {
                 let (loc, desc) = describe(scc[0]);
-                self.errors.push(SafetyError {
+                self.push_error(SafetyError {
                     location: loc,
                     message: format!("--no-recursion: {} is recursive", desc),
                 });
@@ -1918,7 +1957,7 @@ impl SafetyChecker {
                 let cycle_desc = descs.join(", ");
                 for &n in scc {
                     let (loc, desc) = describe(n);
-                    self.errors.push(SafetyError {
+                    self.push_error(SafetyError {
                         location: loc,
                         message: format!(
                             "--no-recursion: {} participates in a recursive cycle [{}]",
@@ -3159,6 +3198,162 @@ mod tests {
 
         let errors = check(s);
         // u32 is known to be >= 0, so only the upper bound is unproven.
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    pub fn test_lambda_capture_assigned_after_definition_div() {
+        let s = "
+        f() {
+            var d = 1
+            var g = (| | 100 / d)
+            d = 0
+        }
+        ";
+
+        let errors = check(s);
+        // g runs at an unknown time, and d is 0 by then.
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    pub fn test_lambda_capture_assigned_after_definition_index() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var i = 5
+            var g = (| | a[i])
+            i = 1000
+        }
+        ";
+
+        let errors = check(s);
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    pub fn test_lambda_capture_unassigned_keeps_constraint() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var i = 5
+            var g = (| | a[i])
+            let j = i
+        }
+        ";
+
+        let errors = check(s);
+        // i is never assigned, so the definition-site interval still holds.
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    pub fn test_lambda_assignment_seen_through_enclosing_loop() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var i = 5
+            for k in 0 .. 10 {
+                var g = (| | i = 1000)
+            }
+            let x = a[i]
+        }
+        ";
+
+        let errors = check(s);
+        // The loop's invalidation has to reach the assignment inside the lambda.
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    pub fn test_lambda_self_assigned_capture_unconstrained() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            var i = 5
+            var g = (| | { let x = a[i]
+                           i = 1000 })
+        }
+        ";
+
+        let errors = check(s);
+        // g can be called more than once, so i is not [5, 5] in the body.
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    pub fn test_lambda_len_bound_survives_shadowing_param() {
+        let s = "
+        f() {
+            var small: [i32; 4]
+            var a: [i32; 100]
+            for j in 0 .. a.len {
+                let z = (|a: [i32; 4], i: i32| a[i])(small, j)
+            }
+        }
+        ";
+
+        let errors = check(s);
+        // `j < a.len` is about the 100-element a, not the 4-element param.
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    pub fn test_lambda_len_bound_inherited_by_param() {
+        let s = "
+        f() {
+            var a: [i32; 100]
+            for j in 0 .. a.len {
+                let z = (|i| a[i])(j)
+            }
+        }
+        ";
+
+        let errors = check(s);
+        // The param inherits `j < a.len` from the argument.
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    pub fn test_lambda_in_tuple_is_checked() {
+        let s = "
+        f() {
+            var a: [i32; 4]
+            let t = (1, (|i: i32| a[i]))
+        }
+        ";
+
+        let errors = check(s);
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    pub fn test_index_under_as_ty_is_checked() {
+        let s = "
+        f() {
+            var a: [i32; 4]
+            let x = (a[5] as f32)
+        }
+        ";
+
+        let errors = check(s);
+        // The operand of an `as` cast is still checked.
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    pub fn test_lambda_error_reported_once() {
+        let s = "
+        f() {
+            var a: [i32; 4]
+            var b: [i32; 4]
+            var y = 1
+            if a.len > (|i| b[i])(1000) { let z = y }
+        }
+        ";
+
+        let errors = check(s);
+        // match_expr visits the rhs twice; the diagnostic is still reported once.
         assert_eq!(errors.len(), 1);
     }
 }

--- a/stdlib.lyte
+++ b/stdlib.lyte
@@ -143,6 +143,8 @@ ftoa(dst: [i8], n: f32) {
             dst[i] = 45 as i8
             phase = 1
         } else if phase == 1 {
+            // phase leaves 1 as soon as div reaches 0, and div starts at 1.
+            assume div != 0
             dst[i] = ((int_part / div) % 10 + 48) as i8
             div = div / 10
             if div == 0 {
@@ -152,6 +154,8 @@ ftoa(dst: [i8], n: f32) {
             dst[i] = 46 as i8
             phase = 3
         } else if phase == 3 {
+            // phase leaves 3 as soon as frac_div reaches 0.
+            assume frac_div != 0
             dst[i] = ((frac_part / frac_div) % 10 + 48) as i8
             frac_div = frac_div / 10
             if frac_div == 0 {

--- a/tests/cases/lambdas/lambda_capture_assigned.lyte
+++ b/tests/cases/lambdas/lambda_capture_assigned.lyte
@@ -1,0 +1,20 @@
+// A lambda runs at some unknown point after its definition, so a captured
+// variable the enclosing function assigns to can't be trusted inside the body
+// — even though it holds a safe value at the definition site.
+//
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/lambdas/lambda_capture_assigned.lyte:17:18: couldn't prove index is >= 0
+//         var g = (| | arr[i])
+//                      ^
+// ❌ ../tests/cases/lambdas/lambda_capture_assigned.lyte:17:18: couldn't prove index is less than array length
+//         var g = (| | arr[i])
+//                      ^
+
+main {
+    var arr: [i32; 4]
+    var i = 2
+    var g = (| | arr[i])
+    i = 1000
+    print(g())
+}

--- a/tests/cases/lambdas/lambda_div_zero.lyte
+++ b/tests/cases/lambdas/lambda_div_zero.lyte
@@ -1,0 +1,12 @@
+// Division by an unconstrained lambda parameter.
+//
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/lambdas/lambda_div_zero.lyte:10:25: couldn't prove divisor is non-zero
+//         var g = (|d| 100 / d)
+//                             ^
+
+main {
+    var g = (|d| 100 / d)
+    print(g(0))
+}

--- a/tests/cases/lambdas/lambda_guarded_ok.lyte
+++ b/tests/cases/lambdas/lambda_guarded_ok.lyte
@@ -1,0 +1,21 @@
+// A lambda that guards its own parameter is provably safe, so the checker
+// accepts it. Only checked, not run: a lambda that captures an array still
+// misbehaves on the vm/asm/stack backends (unrelated to the safety checker).
+//
+// args: --check
+// expected stdout:
+
+main {
+    var arr: [i32; 4]
+    arr[2] = 11
+
+    // Guarded index and guarded divisor.
+    var g = (|i| if i >= 0 && i < arr.len { arr[i] } else { -1 })
+    var h = (|d| if d != 0 { 100 / d } else { 0 })
+    print(g(1000))
+    print(h(0))
+
+    // Immediately invoked: checked against the actual argument, which is
+    // known to be in bounds.
+    print((|i| arr[i])(2))
+}

--- a/tests/cases/lambdas/lambda_hof_unproven.lyte
+++ b/tests/cases/lambdas/lambda_hof_unproven.lyte
@@ -1,0 +1,20 @@
+// A lambda passed to a higher-order function is checked at its definition
+// site, where the argument it will be called with is unknown.
+//
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/lambdas/lambda_hof_unproven.lyte:19:21: couldn't prove index is >= 0
+//         print(apply(|i| arr[i], 2))
+//                         ^
+// ❌ ../tests/cases/lambdas/lambda_hof_unproven.lyte:19:21: couldn't prove index is less than array length
+//         print(apply(|i| arr[i], 2))
+//                         ^
+
+apply(f: (i32) → i32, x: i32) → i32 {
+    return f(x)
+}
+
+main {
+    var arr: [i32; 4]
+    print(apply(|i| arr[i], 2))
+}

--- a/tests/cases/lambdas/lambda_immediate_call_ok.lyte
+++ b/tests/cases/lambdas/lambda_immediate_call_ok.lyte
@@ -1,0 +1,12 @@
+// An immediately-invoked lambda is checked against its actual arguments, so
+// the divisor here is known to be non-zero.
+//
+// expected stdout:
+// compilation successful
+// 20
+// 42
+
+main {
+    print((|d| 100 / d)(5))
+    print((|x| x * 2)(21))
+}

--- a/tests/cases/lambdas/lambda_index_unproven.lyte
+++ b/tests/cases/lambdas/lambda_index_unproven.lyte
@@ -1,0 +1,18 @@
+// A lambda body is checked like a function body: nothing is known about its
+// parameters at the definition site, so an unguarded index is rejected.
+//
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/lambdas/lambda_index_unproven.lyte:16:18: couldn't prove index is >= 0
+//         var g = (|i| arr[i])
+//                      ^
+// ❌ ../tests/cases/lambdas/lambda_index_unproven.lyte:16:18: couldn't prove index is less than array length
+//         var g = (|i| arr[i])
+//                      ^
+
+main {
+    var arr: [i32; 4]
+    arr[0] = 11
+    var g = (|i| arr[i])
+    print(g(1000))
+}

--- a/tests/cases/lambdas/lambda_nested_unproven.lyte
+++ b/tests/cases/lambdas/lambda_nested_unproven.lyte
@@ -1,0 +1,16 @@
+// A lambda nested inside another lambda is checked as well.
+//
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/lambdas/lambda_nested_unproven.lyte:14:23: couldn't prove index is >= 0
+//         var g = (|i| (|j| arr[j])(i))
+//                           ^
+// ❌ ../tests/cases/lambdas/lambda_nested_unproven.lyte:14:23: couldn't prove index is less than array length
+//         var g = (|i| (|j| arr[j])(i))
+//                           ^
+
+main {
+    var arr: [i32; 4]
+    var g = (|i| (|j| arr[j])(i))
+    print(g(1000))
+}

--- a/tests/cases/lambdas/lambda_require.lyte
+++ b/tests/cases/lambdas/lambda_require.lyte
@@ -1,0 +1,22 @@
+// Require clauses are proved at call sites inside a lambda body.
+//
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/lambdas/lambda_require.lyte:19:18: couldn't prove require clause `idx >= 0` for call to `wm`
+//         var g = (|i| wm(arr, i, 5))
+//                      ^
+// ❌ ../tests/cases/lambdas/lambda_require.lyte:19:18: couldn't prove require clause `idx < buf.len` for call to `wm`
+//         var g = (|i| wm(arr, i, 5))
+//                      ^
+
+wm(buf: [i32], idx: i32, v: i32)
+require idx >= 0
+require idx < buf.len
+{ buf[idx] = v }
+
+main {
+    var arr: [i32; 4]
+    var g = (|i| wm(arr, i, 5))
+    g(1000)
+    print(arr[0])
+}

--- a/tests/cases/lambdas/lambda_struct_lit_unproven.lyte
+++ b/tests/cases/lambdas/lambda_struct_lit_unproven.lyte
@@ -1,0 +1,19 @@
+// A lambda stored in a struct literal is checked like any other lambda: the
+// struct literal is not a hiding place for an unguarded index.
+//
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/lambdas/lambda_struct_lit_unproven.lyte:17:23: couldn't prove index is >= 0
+//         var s = S(f: (|i| arr[i]))
+//                           ^
+// ❌ ../tests/cases/lambdas/lambda_struct_lit_unproven.lyte:17:23: couldn't prove index is less than array length
+//         var s = S(f: (|i| arr[i]))
+//                           ^
+
+struct S { f: (i32) → i32 }
+
+main {
+    var arr: [i32; 4]
+    var s = S(f: (|i| arr[i]))
+    print(s.f(1000))
+}

--- a/tests/cases/lambdas/lambda_write_unproven.lyte
+++ b/tests/cases/lambdas/lambda_write_unproven.lyte
@@ -1,0 +1,18 @@
+// Writes through a lambda parameter are checked too — this used to be a
+// silent out-of-bounds store on every backend.
+//
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/lambdas/lambda_write_unproven.lyte:15:18: couldn't prove index is >= 0
+//         var g = (|i| arr[i] = 7)
+//                      ^
+// ❌ ../tests/cases/lambdas/lambda_write_unproven.lyte:15:18: couldn't prove index is less than array length
+//         var g = (|i| arr[i] = 7)
+//                      ^
+
+main {
+    var arr: [i32; 4]
+    var g = (|i| arr[i] = 7)
+    g(1000)
+    print(arr[0])
+}


### PR DESCRIPTION
Fixes #39.

`SafetyChecker::check_expr` had no `Expr::Lambda` arm, so lambdas fell into the catch-all and their bodies were never visited — array bounds, divisor non-zero, and `require` clauses at call sites were all skipped inside one. Since safety here is entirely static, nothing was checking at all: an out-of-bounds store through a lambda parameter was silent on every backend.

## What changed

New `check_lambda_body` helper binds the parameters and checks the body:

- Param types come from the annotation when present, otherwise from the solved `Type::Func` domain of the lambda expression (lambda params are usually unannotated), so `u32` params still get `min = 0`.
- Params shadow captured variables of the same name; other captures keep the constraints they have at the definition site.
- Checker state is saved/restored around the body, then `invalidate_assigned` runs — a lambda that writes a captured variable conservatively drops what was known about it, since the write happens at an unknown call time.

`Expr::Call` checks an immediately-invoked lambda literal against its actual argument intervals (inheriting the arguments' symbolic `len` bounds), so `(|i| arr[i])(2)` is still accepted while `(|i| arr[i])(1000)` is rejected.

A lambda that is stored in a variable, passed to a higher-order function, or nested is checked with unconstrained parameters — the same rule as a function body — so it has to guard itself:

```rust
var g = (|i| if i >= 0 && i < arr.len { arr[i] } else { -1 })   // accepted
var g = (|i| arr[i])                                            // rejected
```

Relating call-site arguments back to a lambda bound to a variable (`var g = (|i| arr[i]); g(2)`) is deliberately not attempted: it needs the binding to be provably unreassigned and non-escaping, which is a design decision rather than part of closing the hole.

## Tests

All four repros from #39 now fail `--check` with the same diagnostics the identical non-lambda code produces.

- 12 unit tests in `safety_checker.rs` (unconstrained/guarded index, write, divisor, capture, shadowing, direct call safe/unsafe, nested, capture invalidation, `u32` param).
- 8 golden tests in `tests/cases/lambdas/` — 6 rejection cases (read, write, divide, `require`, nested, HOF) and 2 acceptance cases.

`cargo test --workspace` passes: 369 lib + 4 golden (jit/vm/asm/stack) + 21 lsp. No existing test changed behavior. `cargo fmt --check` is clean for the touched file.

## Follow-up: closing the remaining holes (4779192)

A review of the first commit turned up six more gaps, all fixed here.

**Captures mutated after the definition site.** `check_lambda_body` checked the body against the constraint state where the lambda was *written*, but a lambda runs at some unknown later point, so a capture the enclosing function assigns to may hold a different value by then:

```rust
var d = 1
var g = (| | 100 / d)
d = 0
print(g())            // passed --check, trapped at runtime
```

`SafetyChecker` now tracks every variable assigned anywhere in the function and forgets those before checking a lambda body. An immediately-invoked lambda is exempt — its definition site *is* its call site, so the current state is exact and `(|i| arr[i])(2)` is still accepted. This also covers a lambda that writes its own capture and is called more than once: the write puts the name in the assigned set.

**Assignments hidden from the traversals.** `collect_assigned_vars` had no arm for `Lambda`, `Var`, `Let` or `Call`, so an enclosing loop's `invalidate_assigned` couldn't see a write nested in any of them — the new invalidation was silently undone by any surrounding loop. `is_monotonic_increment` had the same gap behind a `_ => true` catch-all, and the `For` arm calls it right after invalidating, so a write inside a lambda still looked like an increment and the pre-loop min bound was handed back. Both now walk the whole tree via `subexprs()`.

**Symbolic length bounds read from the entry snapshot** rather than live state, resurrecting a bound about an array name an earlier parameter had already shadowed: `(|a, i| a[i])(small, j)` inherited `j < a.len` for the 100-element `a` and applied it to the 4-element parameter.

**`Tuple`, `StructLit`, `AsTy` and `Arena`** fell into the `check_expr` catch-all, so a lambda stored in a struct literal was never checked at all — the most obvious storage location for a callback.

**Duplicate diagnostics.** `match_expr` visits some subexpressions twice, which surfaced as the same error reported twice now that `check_expr` descends into lambda bodies. Errors go through a helper that drops exact `(location, message)` duplicates.

### stdlib change

Checking `AsTy` operands exposed two divisions in `ftoa` (`int_part / div` and `frac_part / frac_div`) that had never been checked, because the casts hid them from the traversal. Both are safe — `div` starts at 1 and `phase` leaves the branch as soon as it reaches 0 — but that's phase-based reasoning the checker can't do, so they get `assume` clauses documenting the invariant, the same way `sort` already does. Without this every program failed to compile, including `main { print(1) }`.

### Tests

10 more unit tests and 2 more golden tests, one per finding, plus controls confirming the precision that should be kept (an unassigned capture still keeps its interval; a param still inherits `j < a.len` from its argument). `cargo test --workspace`: 379 lib + 4 golden + 21 lsp. All five `benchmark/*.lyte` programs still pass `--check`.

## Unrelated bug found while writing the tests

A lambda that **captures an array** misbehaves on every non-JIT backend, independent of this change (the safety checker only emits diagnostics):

```rust
main {
    var arr: [i32; 4]
    arr[2] = 11
    var g = (|x| arr[2] + x)
    print(g(1))
}
```

JIT prints `12`; the VM panics at `src/vm.rs:1283` (`attempt to subtract with overflow`, from `self.ip - 1` inside the out-of-bounds-access panic message); asm and stack exit 139. That is why `lambda_guarded_ok.lyte` is `--check`-only, with a comment saying so. Filed as #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)