### PR TITLE
Bridge f32/f64 across closure calls on the stack backend

### DIFF
--- a/src/stack_codegen.rs
+++ b/src/stack_codegen.rs
@@ -1691,9 +1691,7 @@ impl<'a> FunctionTranslator<'a> {
 
         if is_local_var {
             // Push arguments first, then the fat pointer address.
-            for arg_id in arg_ids {
-                self.translate_expr(*arg_id, func);
-            }
+            self.push_closure_args(arg_ids, func);
             self.translate_expr(fn_id, func); // pushes fat_ptr_addr
             func.emit(StackOp::CallClosure {
                 args: arg_ids.len() as u8,
@@ -2082,9 +2080,7 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // Indirect call via expression.
-        for arg_id in arg_ids {
-            self.translate_expr(*arg_id, func);
-        }
+        self.push_closure_args(arg_ids, func);
         self.translate_expr(fn_id, func); // pushes fat_ptr_addr
         func.emit(StackOp::CallClosure {
             args: arg_ids.len() as u8,
@@ -2092,10 +2088,24 @@ impl<'a> FunctionTranslator<'a> {
         self.bridge_call_result(call_expr, func);
     }
 
+    /// Push the arguments for a `CallClosure`. Like `op_call`, `op_call_closure`
+    /// copies args out of the int TOS window, so f32/f64 args that rode through
+    /// the float window have to be bridged back to their bit pattern.
+    fn push_closure_args(&mut self, arg_ids: &[ExprID], func: &mut StackFunction) {
+        for arg_id in arg_ids {
+            self.translate_expr(*arg_id, func);
+            match &*self.expr_type(*arg_id) {
+                Type::Float32 => func.emit(StackOp::FToBitsF),
+                Type::Float64 => func.emit(StackOp::DToBitsD),
+                _ => {}
+            }
+        }
+    }
+
     /// Fix up the result of a `CallClosure`. Void calls leave nothing on the
     /// operand stack, so push a placeholder to keep translate_call's +1
     /// invariant. Float returns come back through t0 (the int window) and must
-    /// be bridged into the float/double window, same as the direct-call path.
+    /// be bridged into the float/double window.
     fn bridge_call_result(&mut self, call_expr: ExprID, func: &mut StackFunction) {
         match &*self.expr_type(call_expr) {
             Type::Void => func.emit(StackOp::I64Const(0)),

--- a/src/stack_codegen.rs
+++ b/src/stack_codegen.rs
@@ -1698,12 +1698,7 @@ impl<'a> FunctionTranslator<'a> {
             func.emit(StackOp::CallClosure {
                 args: arg_ids.len() as u8,
             });
-            // Closure over a void function leaves no return value on the
-            // stack; push a placeholder so translate_call's +1 invariant
-            // holds.
-            if matches!(&*self.expr_type(call_expr), Type::Void) {
-                func.emit(StackOp::I64Const(0));
-            }
+            self.bridge_call_result(call_expr, func);
             return;
         }
 
@@ -2094,8 +2089,19 @@ impl<'a> FunctionTranslator<'a> {
         func.emit(StackOp::CallClosure {
             args: arg_ids.len() as u8,
         });
-        if matches!(&*self.expr_type(call_expr), Type::Void) {
-            func.emit(StackOp::I64Const(0));
+        self.bridge_call_result(call_expr, func);
+    }
+
+    /// Fix up the result of a `CallClosure`. Void calls leave nothing on the
+    /// operand stack, so push a placeholder to keep translate_call's +1
+    /// invariant. Float returns come back through t0 (the int window) and must
+    /// be bridged into the float/double window, same as the direct-call path.
+    fn bridge_call_result(&mut self, call_expr: ExprID, func: &mut StackFunction) {
+        match &*self.expr_type(call_expr) {
+            Type::Void => func.emit(StackOp::I64Const(0)),
+            Type::Float32 => func.emit(StackOp::BitsToFF),
+            Type::Float64 => func.emit(StackOp::BitsToDD),
+            _ => {}
         }
     }
 

--- a/tests/cases/lambdas/lambda_float_return.lyte
+++ b/tests/cases/lambdas/lambda_float_return.lyte
@@ -1,0 +1,20 @@
+// expected stdout:
+// compilation successful
+// assert(true)
+// assert(true)
+// assert(true)
+
+apply32(f: i32 → f32) → f32 { f(0) }
+apply64(f: i32 → f64) → f64 { f(0) }
+
+main {
+    var x = 1.5
+    assert(apply32((|i| x + 1.0)) == 2.5)
+
+    var y = 1.5f64
+    assert(apply64((|i| y + 1.0f64)) == 2.5f64)
+
+    // Indirect call through a local variable holding a closure.
+    var g = (|i: i32| x * 2.0)
+    assert(g(0) == 3.0)
+}

--- a/tests/cases/lambdas/lambda_float_return.lyte
+++ b/tests/cases/lambdas/lambda_float_return.lyte
@@ -3,9 +3,13 @@
 // assert(true)
 // assert(true)
 // assert(true)
+// assert(true)
+// assert(true)
 
 apply32(f: i32 → f32) → f32 { f(0) }
 apply64(f: i32 → f64) → f64 { f(0) }
+apply_arg32(f: f32 → f32, x: f32) → f32 { f(x) }
+apply_arg64(f: f64 → f64, x: f64) → f64 { f(x) }
 
 main {
     var x = 1.5
@@ -17,4 +21,12 @@ main {
     // Indirect call through a local variable holding a closure.
     var g = (|i: i32| x * 2.0)
     assert(g(0) == 3.0)
+
+    // Float arguments have to be bridged into the int window too. A
+    // non-literal argument is what exercises the bridge.
+    var v = 2.0
+    assert(apply_arg32((|a| a + 1.0), v) == 3.0)
+
+    var w = 2.0f64
+    assert(apply_arg64((|a| a + 1.0f64), w) == 3.0f64)
 }


### PR DESCRIPTION
Fixes #40.

## Problem

On the `stack` backend, closure calls mishandled `f32`/`f64` in **both** directions. `jit`, `vm`, and `asm` were correct.

The interpreter passes floats through the int window across a call boundary: `op_call` / `op_call_closure` copy arguments out of the int TOS window, and return values come back through `t0`. The direct-call path bridges both ends (`FToBitsF`/`DToBitsD` going in, `BitsToFF`/`BitsToDD` coming out). Both `CallClosure` sites did neither — they only pushed a placeholder for the `Void` case.

**Returns** (the reported bug in #40) — the next float-window op ran on an empty window, which the compiler's own balance check flagged as `apply: f-window underflow at op 3 (FToBitsF): in=0 delta=-1`:

```
apply(f: i32 -> f32) -> f32 { f(0) }
main { var x = 1.5; assert(apply((|i| x + 1.0)) == 2.5) }
# jit/vm/asm: assert(true)   stack: assert(false) -> trap
```

**Arguments** (found in review, second commit) — the mirror image. A non-literal float argument reached the callee as garbage; a literal happened to work, which is why it hid:

```
main { var g = (|a: f32| a + 1.0); var v = 2.0; assert(g(v) == 3.0) }
# jit/vm/asm: assert(true)   stack: assert(false) -> trap
```

## Fix

Two helpers now own the `CallClosure` ABI, used by both call sites:

- `push_closure_args` — bridges `f32`/`f64` args into the int window before the call.
- `bridge_call_result` — pushes the `Void` placeholder, or bridges an `f32`/`f64` return back into the float/double window.

## Test

`tests/cases/lambdas/lambda_float_return.lyte` covers f32 and f64 returns from a closure passed to a higher-order function, a call through a local variable holding a closure, and f32/f64 arguments passed non-literally. Golden tests run once per backend, so all of this is checked on jit/vm/asm/stack.

`cargo test --workspace` is green (358 lib + 4 golden + 21 lsp).

## Out of scope

Two adjacent pre-existing bugs found during review, filed separately rather than expanded into this PR:

- #44 — struct-returning (sret) closures and function pointers segfault on `stack` and panic on `vm`; the `CallClosure` sites also never grew the `Reference`/`Slice` parameter coercion the direct-call path has.
- #45 — arrays of lambdas are broken on every backend. This is why the test covers only the local-variable `CallClosure` site: there's currently no working way to reach the indirect-expression site with a float-returning closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)