### PR TITLE
Give closure calls the same ABI as direct calls

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1257,23 +1257,49 @@ impl Checker {
         decls: &DeclTable,
         func_decl: &FuncDecl,
     ) -> Vec<usize> {
-        let Expr::Id(callee_name) = &func_decl.arena[callee] else {
-            return Vec::new();
-        };
-
         let mut positions = Vec::new();
-        for d in decls.find(*callee_name) {
-            if let Decl::Func(fd) = d {
-                for (i, param) in fd.params.iter().enumerate() {
-                    if let Some(ty) = param.ty {
-                        if matches!(*ty, Type::Reference(_)) && !positions.contains(&i) {
-                            positions.push(i);
+        let mut found_decl = false;
+
+        if let Expr::Id(callee_name) = &func_decl.arena[callee] {
+            for d in decls.find(*callee_name) {
+                if let Decl::Func(fd) = d {
+                    found_decl = true;
+                    for (i, param) in fd.params.iter().enumerate() {
+                        if let Some(ty) = param.ty {
+                            if matches!(*ty, Type::Reference(_)) && !positions.contains(&i) {
+                                positions.push(i);
+                            }
                         }
                     }
                 }
             }
         }
-        positions
+
+        if found_decl {
+            return positions;
+        }
+
+        // Indirect call through a fat pointer. There is no declaration to
+        // consult, so take the parameter types from the callee expression's
+        // solved type — the same source the backends use to decide which
+        // arguments to pass by address.
+        self.callee_param_types(callee)
+            .iter()
+            .enumerate()
+            .filter(|(_, ty)| matches!(***ty, Type::Reference(_)))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Parameter types of a callee expression, from its solved type. Used for
+    /// indirect calls, where there is no declaration to consult.
+    fn callee_param_types(&self, callee: ExprID) -> Vec<TypeID> {
+        if let Type::Func(from, _) = &*self.types[callee].subst(&self.inst) {
+            if let Type::Tuple(params) = &**from {
+                return params.clone();
+            }
+        }
+        Vec::new()
     }
 
     /// Enforce the no-alias rule: two borrowed parameters in the same call must not
@@ -1289,27 +1315,39 @@ impl Checker {
                 continue;
             };
 
-            // Only check direct named calls — indirect calls (lambdas) can't
-            // have slice parameters (slices can't appear in function types).
-            let Expr::Id(callee_name) = &func_decl.arena[*f] else {
-                continue;
-            };
-
             // Find which parameter positions are borrowed in the callee's declaration.
             // For overloaded functions, union all borrowed positions (conservative).
-            let callee_decls = decls.find(*callee_name);
             let mut borrow_positions: Vec<(usize, bool)> = Vec::new();
-            for d in callee_decls {
-                if let Decl::Func(fd) = d {
-                    for (i, param) in fd.params.iter().enumerate() {
-                        if let Some(ty) = param.ty {
-                            let is_slice = matches!(*ty, Type::Slice(_));
-                            if matches!(*ty, Type::Slice(_) | Type::Reference(_))
-                                && !borrow_positions.iter().any(|(pos, _)| *pos == i)
-                            {
-                                borrow_positions.push((i, is_slice));
+            let mut found_decl = false;
+            if let Expr::Id(callee_name) = &func_decl.arena[*f] {
+                for d in decls.find(*callee_name) {
+                    if let Decl::Func(fd) = d {
+                        found_decl = true;
+                        for (i, param) in fd.params.iter().enumerate() {
+                            if let Some(ty) = param.ty {
+                                let is_slice = matches!(*ty, Type::Slice(_));
+                                if matches!(*ty, Type::Slice(_) | Type::Reference(_))
+                                    && !borrow_positions.iter().any(|(pos, _)| *pos == i)
+                                {
+                                    borrow_positions.push((i, is_slice));
+                                }
                             }
                         }
+                    }
+                }
+            }
+
+            // Indirect call through a fat pointer: fall back to the callee
+            // expression's solved type. Slices can't appear in function types,
+            // but references can, so this catches aliased borrowed arguments
+            // that would otherwise slip through the closure call path.
+            if !found_decl {
+                for (i, ty) in self.callee_param_types(*f).iter().enumerate() {
+                    let is_slice = matches!(**ty, Type::Slice(_));
+                    if matches!(**ty, Type::Slice(_) | Type::Reference(_))
+                        && !borrow_positions.iter().any(|(pos, _)| *pos == i)
+                    {
+                        borrow_positions.push((i, is_slice));
                     }
                 }
             }

--- a/src/stack_codegen.rs
+++ b/src/stack_codegen.rs
@@ -1690,13 +1690,7 @@ impl<'a> FunctionTranslator<'a> {
         };
 
         if is_local_var {
-            // Push arguments first, then the fat pointer address.
-            self.push_closure_args(arg_ids, func);
-            self.translate_expr(fn_id, func); // pushes fat_ptr_addr
-            func.emit(StackOp::CallClosure {
-                args: arg_ids.len() as u8,
-            });
-            self.bridge_call_result(call_expr, func);
+            self.translate_closure_call(fn_id, arg_ids, call_expr, func);
             return;
         }
 
@@ -2080,24 +2074,79 @@ impl<'a> FunctionTranslator<'a> {
         }
 
         // Indirect call via expression.
-        self.push_closure_args(arg_ids, func);
+        self.translate_closure_call(fn_id, arg_ids, call_expr, func);
+    }
+
+    /// Translate a call through a fat pointer (lambda, closure or function
+    /// pointer). Mirrors the direct-call ABI: an sret output pointer is passed
+    /// as the first argument, `Reference` params are passed by address, and
+    /// sized arrays are wrapped as slices where the callee expects one.
+    fn translate_closure_call(
+        &mut self,
+        fn_id: ExprID,
+        arg_ids: &[ExprID],
+        call_expr: ExprID,
+        func: &mut StackFunction,
+    ) {
+        let ret_ty = self.expr_type(call_expr);
+        let output_slot = if returns_via_pointer(ret_ty) {
+            let size = ret_ty.size(self.decls) as u32;
+            Some(self.alloc_memory(size))
+        } else {
+            None
+        };
+
+        // Push the output pointer as the first argument if sret.
+        if let Some(slot) = output_slot {
+            func.emit(StackOp::LocalAddr(slot));
+        }
+
+        // Push arguments, then the fat pointer address.
+        self.push_closure_args(fn_id, arg_ids, func);
         self.translate_expr(fn_id, func); // pushes fat_ptr_addr
-        func.emit(StackOp::CallClosure {
-            args: arg_ids.len() as u8,
-        });
-        self.bridge_call_result(call_expr, func);
+
+        let args = arg_ids.len() as u8 + u8::from(output_slot.is_some());
+        func.emit(StackOp::CallClosure { args });
+
+        if let Some(slot) = output_slot {
+            // sret callees return void; the result is the output storage.
+            func.emit(StackOp::LocalAddr(slot));
+        } else {
+            self.bridge_call_result(call_expr, func);
+        }
+    }
+
+    /// Parameter types of a callee reached through a fat pointer, taken from
+    /// the function expression's solved type.
+    fn closure_param_types(&self, fn_id: ExprID) -> Vec<TypeID> {
+        if let Type::Func(from, _) = &*self.expr_type(fn_id) {
+            if let Type::Tuple(param_types) = &**from {
+                return param_types.clone();
+            }
+        }
+        vec![]
     }
 
     /// Push the arguments for a `CallClosure`. Like `op_call`, `op_call_closure`
     /// copies args out of the int TOS window, so f32/f64 args that rode through
     /// the float window have to be bridged back to their bit pattern.
-    fn push_closure_args(&mut self, arg_ids: &[ExprID], func: &mut StackFunction) {
-        for arg_id in arg_ids {
-            self.translate_expr(*arg_id, func);
-            match &*self.expr_type(*arg_id) {
-                Type::Float32 => func.emit(StackOp::FToBitsF),
-                Type::Float64 => func.emit(StackOp::DToBitsD),
-                _ => {}
+    fn push_closure_args(&mut self, fn_id: ExprID, arg_ids: &[ExprID], func: &mut StackFunction) {
+        let param_types = self.closure_param_types(fn_id);
+        for (i, arg_id) in arg_ids.iter().enumerate() {
+            let param_ty = param_types.get(i).copied();
+            if param_ty.is_some_and(|t| matches!(&*t, Type::Reference(_))) {
+                self.translate_lvalue(*arg_id, func);
+            } else {
+                self.translate_expr(*arg_id, func);
+                match &*self.expr_type(*arg_id) {
+                    Type::Float32 => func.emit(StackOp::FToBitsF),
+                    Type::Float64 => func.emit(StackOp::DToBitsD),
+                    _ => {}
+                }
+            }
+            if param_ty.is_some_and(|t| matches!(&*t, Type::Slice(_))) {
+                let actual_ty = self.representation_type(*arg_id);
+                self.emit_wrap_as_slice(actual_ty, func);
             }
         }
     }

--- a/src/stack_codegen.rs
+++ b/src/stack_codegen.rs
@@ -1682,14 +1682,7 @@ impl<'a> FunctionTranslator<'a> {
         call_expr: ExprID,
         func: &mut StackFunction,
     ) {
-        // Check if it's a local variable (lambda/function pointer) — use CallClosure.
-        let is_local_var = if let Expr::Id(name) = &self.decl.arena.exprs[fn_id] {
-            self.variables.contains_key(name)
-        } else {
-            false
-        };
-
-        if is_local_var {
+        if self.holds_fat_pointer(fn_id) {
             self.translate_closure_call(fn_id, arg_ids, call_expr, func);
             return;
         }
@@ -2114,6 +2107,28 @@ impl<'a> FunctionTranslator<'a> {
         } else {
             self.bridge_call_result(call_expr, func);
         }
+    }
+
+    /// True when the callee expression names storage holding a fat pointer
+    /// {func_idx, closure_ptr} — a local variable or a function-typed global —
+    /// rather than naming a function declaration. Such calls go through
+    /// `translate_closure_call` instead of the direct-call path.
+    fn holds_fat_pointer(&self, fn_id: ExprID) -> bool {
+        let Expr::Id(name) = &self.decl.arena.exprs[fn_id] else {
+            return false;
+        };
+        if self.variables.contains_key(name) {
+            return true;
+        }
+        // Extern functions live in globals memory too, but they are called
+        // through the direct-call path.
+        self.globals.contains_key(name)
+            && matches!(&*self.expr_type(fn_id), Type::Func(_, _))
+            && !self
+                .decls
+                .find(*name)
+                .iter()
+                .any(|d| matches!(d, Decl::Func(f) if f.is_extern))
     }
 
     /// Parameter types of a callee reached through a fat pointer, taken from

--- a/src/vm_codegen.rs
+++ b/src/vm_codegen.rs
@@ -452,7 +452,7 @@ fn type_to_extern_types(ty: TypeID) -> Vec<crate::vm::ExternType> {
 fn returns_via_pointer(ty: TypeID) -> bool {
     matches!(
         &*ty,
-        Type::Array(_, _) | Type::Slice(_) | Type::Name(_, _) | Type::Tuple(_)
+        Type::Array(_, _) | Type::Slice(_) | Type::Name(_, _) | Type::Tuple(_) | Type::Float32x4
     )
 }
 
@@ -2276,36 +2276,7 @@ impl<'a> FunctionTranslator<'a> {
         };
 
         if is_local_var {
-            let fat_ptr_reg = self.translate_expr(fn_id, func);
-
-            let mut arg_values = Vec::new();
-            for arg_id in arg_ids {
-                arg_values.push(self.translate_expr(*arg_id, func));
-            }
-
-            let args_start = self.next_reg;
-            for (i, &arg_reg) in arg_values.iter().enumerate() {
-                let target = args_start + i as Reg;
-                let _ = self.alloc_reg();
-                if arg_reg != target {
-                    func.emit(Opcode::Move {
-                        dst: target,
-                        src: arg_reg,
-                    });
-                }
-            }
-
-            func.emit(Opcode::CallClosure {
-                fat_ptr: fat_ptr_reg,
-                args_start,
-                arg_count: arg_ids.len() as u8,
-            });
-            let result_reg = self.alloc_reg();
-            func.emit(Opcode::Move {
-                dst: result_reg,
-                src: 0,
-            });
-            return result_reg;
+            return self.translate_closure_call(fn_id, arg_ids, call_expr, func);
         }
 
         // Special handling for built-in functions.
@@ -2732,38 +2703,109 @@ impl<'a> FunctionTranslator<'a> {
         } else {
             // Indirect call via expression (e.g. lambda literal in call position).
             // The expression evaluates to a fat pointer {func_idx, closure_ptr}.
-            let fat_ptr_reg = self.translate_expr(fn_id, func);
-
-            let mut arg_values = Vec::new();
-            for arg_id in arg_ids {
-                arg_values.push(self.translate_expr(*arg_id, func));
-            }
-
-            let args_start = self.next_reg;
-            for (i, &arg_reg) in arg_values.iter().enumerate() {
-                let target = args_start + i as Reg;
-                let _ = self.alloc_reg();
-                if arg_reg != target {
-                    func.emit(Opcode::Move {
-                        dst: target,
-                        src: arg_reg,
-                    });
-                }
-            }
-
-            func.emit(Opcode::CallClosure {
-                fat_ptr: fat_ptr_reg,
-                args_start,
-                arg_count: arg_ids.len() as u8,
-            });
-
-            let result_reg = self.alloc_reg();
-            func.emit(Opcode::Move {
-                dst: result_reg,
-                src: 0,
-            });
-            result_reg
+            self.translate_closure_call(fn_id, arg_ids, call_expr, func)
         }
+    }
+
+    /// Translate a call through a fat pointer {func_idx, closure_ptr}. Mirrors
+    /// the direct-call ABI: an sret output pointer is passed as the first
+    /// argument, `Reference` params are passed by address, and sized arrays are
+    /// wrapped as slices where the callee expects one.
+    fn translate_closure_call(
+        &mut self,
+        fn_id: ExprID,
+        arg_ids: &[ExprID],
+        call_expr: ExprID,
+        func: &mut VMFunction,
+    ) -> Reg {
+        let fat_ptr_reg = self.translate_expr(fn_id, func);
+
+        // Parameter types of the callee, taken from the solved type of the
+        // function expression.
+        let param_types: Vec<TypeID> = if let Type::Func(from, _) = &*self.expr_type(fn_id) {
+            if let Type::Tuple(param_types) = &**from {
+                param_types.clone()
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        };
+
+        let ret_ty = self.expr_type(call_expr);
+        let output_slot = if returns_via_pointer(ret_ty) {
+            let size = ret_ty.size(self.decls);
+            Some(self.alloc_local(size as u32))
+        } else {
+            None
+        };
+
+        let mut arg_values = Vec::new();
+        for (i, arg_id) in arg_ids.iter().enumerate() {
+            let param_ty = param_types.get(i).copied();
+            let arg_reg = if param_ty.is_some_and(|ty| matches!(&*ty, Type::Reference(_))) {
+                self.translate_lvalue(*arg_id, func)
+            } else {
+                self.translate_expr(*arg_id, func)
+            };
+            if param_ty.is_some_and(|ty| matches!(&*ty, Type::Slice(_))) {
+                let wrapped = self.wrap_as_slice(arg_reg, self.representation_type(*arg_id), func);
+                arg_values.push(wrapped);
+                continue;
+            }
+            arg_values.push(arg_reg);
+        }
+
+        let args_start = self.next_reg;
+
+        if let Some(slot) = output_slot {
+            let addr_reg = self.alloc_reg();
+            func.emit(Opcode::LocalAddr {
+                dst: addr_reg,
+                slot,
+            });
+        }
+
+        let first_arg_reg = if output_slot.is_some() {
+            args_start + 1
+        } else {
+            args_start
+        };
+
+        for (i, &arg_reg) in arg_values.iter().enumerate() {
+            let target = first_arg_reg + i as Reg;
+            let _ = self.alloc_reg();
+            if arg_reg != target {
+                func.emit(Opcode::Move {
+                    dst: target,
+                    src: arg_reg,
+                });
+            }
+        }
+
+        func.emit(Opcode::CallClosure {
+            fat_ptr: fat_ptr_reg,
+            args_start,
+            arg_count: arg_ids.len() as u8 + u8::from(output_slot.is_some()),
+        });
+
+        // sret callees return void; the result is the address of the output
+        // storage we passed in.
+        if let Some(slot) = output_slot {
+            let addr_reg = self.alloc_reg();
+            func.emit(Opcode::LocalAddr {
+                dst: addr_reg,
+                slot,
+            });
+            return addr_reg;
+        }
+
+        let result_reg = self.alloc_reg();
+        func.emit(Opcode::Move {
+            dst: result_reg,
+            src: 0,
+        });
+        result_reg
     }
 
     /// Translate an if expression.

--- a/src/vm_codegen.rs
+++ b/src/vm_codegen.rs
@@ -2267,15 +2267,7 @@ impl<'a> FunctionTranslator<'a> {
         call_expr: ExprID,
         func: &mut VMFunction,
     ) -> Reg {
-        // If fn_id is a local variable (lambda or function pointer), use CallClosure.
-        // The variable holds a pointer to a fat pointer {func_idx, closure_ptr}.
-        let is_local_var = if let Expr::Id(name) = &self.decl.arena.exprs[fn_id] {
-            self.variables.contains_key(name)
-        } else {
-            false
-        };
-
-        if is_local_var {
+        if self.holds_fat_pointer(fn_id) {
             return self.translate_closure_call(fn_id, arg_ids, call_expr, func);
         }
 
@@ -2593,16 +2585,7 @@ impl<'a> FunctionTranslator<'a> {
                         vec![]
                     }
                 } else {
-                    let fn_ty = self.expr_type(fn_id);
-                    if let Type::Func(from, _) = &*fn_ty {
-                        if let Type::Tuple(pts) = &**from {
-                            pts.clone()
-                        } else {
-                            vec![]
-                        }
-                    } else {
-                        vec![]
-                    }
+                    self.closure_param_types(fn_id)
                 };
 
             // First, translate all arguments to get their values.
@@ -2707,6 +2690,39 @@ impl<'a> FunctionTranslator<'a> {
         }
     }
 
+    /// True when the callee expression names storage holding a fat pointer
+    /// {func_idx, closure_ptr} — a local variable or a function-typed global —
+    /// rather than naming a function declaration. Such calls go through
+    /// `translate_closure_call` instead of the direct-call path.
+    fn holds_fat_pointer(&self, fn_id: ExprID) -> bool {
+        let Expr::Id(name) = &self.decl.arena.exprs[fn_id] else {
+            return false;
+        };
+        if self.variables.contains_key(name) {
+            return true;
+        }
+        // Extern functions live in globals memory too, but they are called
+        // through the direct-call path.
+        self.globals.contains_key(name)
+            && matches!(&*self.expr_type(fn_id), Type::Func(_, _))
+            && !self
+                .decls
+                .find(*name)
+                .iter()
+                .any(|d| matches!(d, Decl::Func(f) if f.is_extern))
+    }
+
+    /// Parameter types of a callee reached through a fat pointer, taken from
+    /// the function expression's solved type.
+    fn closure_param_types(&self, fn_id: ExprID) -> Vec<TypeID> {
+        if let Type::Func(from, _) = &*self.expr_type(fn_id) {
+            if let Type::Tuple(param_types) = &**from {
+                return param_types.clone();
+            }
+        }
+        vec![]
+    }
+
     /// Translate a call through a fat pointer {func_idx, closure_ptr}. Mirrors
     /// the direct-call ABI: an sret output pointer is passed as the first
     /// argument, `Reference` params are passed by address, and sized arrays are
@@ -2720,17 +2736,7 @@ impl<'a> FunctionTranslator<'a> {
     ) -> Reg {
         let fat_ptr_reg = self.translate_expr(fn_id, func);
 
-        // Parameter types of the callee, taken from the solved type of the
-        // function expression.
-        let param_types: Vec<TypeID> = if let Type::Func(from, _) = &*self.expr_type(fn_id) {
-            if let Type::Tuple(param_types) = &**from {
-                param_types.clone()
-            } else {
-                vec![]
-            }
-        } else {
-            vec![]
-        };
+        let param_types = self.closure_param_types(fn_id);
 
         let ret_ty = self.expr_type(call_expr);
         let output_slot = if returns_via_pointer(ret_ty) {

--- a/tests/cases/globals/global_func_ptr.lyte
+++ b/tests/cases/globals/global_func_ptr.lyte
@@ -1,0 +1,54 @@
+// Calls through a function-typed global go through the fat-pointer call path,
+// with the same ABI as a direct call: scalar, float, void, reference, and
+// sret (struct) returns all have to work.
+// expected stdout:
+// compilation successful
+// 2
+// 42
+// 3
+// 99
+// 6
+// 7
+
+struct P {
+    x: i32
+}
+
+inc(x: i32) → i32 { x + 1 }
+dbl(x: i32) → i32 { x * 2 }
+addf(a: f32, b: f32) → f32 { a + b }
+noop { }
+bump(r: &i32) { r = r + 1 }
+mkp(k: i32) → P {
+    var p: P
+    p.x = k
+    return p
+}
+
+var gi: i32 → i32
+var gf: (f32, f32) → f32
+var gv: void → void
+var gb: &i32 → void
+var gp: i32 → P
+
+main {
+    gi = inc
+    print(gi(1))
+    gi = dbl
+    print(gi(21))
+
+    gf = addf
+    print(gf(1.5, 2.0) as i32)
+
+    gv = noop
+    print(99)
+
+    gb = bump
+    var v = 5
+    gb(v)
+    print(v)
+
+    gp = mkp
+    var q = gp(7)
+    print(q.x)
+}

--- a/tests/cases/lambdas/closure_abi.lyte
+++ b/tests/cases/lambdas/closure_abi.lyte
@@ -1,0 +1,70 @@
+// Calls through a fat pointer (function pointer, lambda, or function-typed
+// parameter) must use the same ABI as direct calls: an sret output pointer for
+// pointer-returned types, reference params passed by address, and sized arrays
+// wrapped as slices.
+// expected stdout:
+// compilation successful
+// assert(true)
+// assert(true)
+// assert(true)
+// assert(true)
+// assert(true)
+// assert(true)
+// assert(true)
+// assert(true)
+// assert(true)
+
+struct P { x: i32, y: i32 }
+
+mk(a: i32) -> P { var p: P; p.x = a; p.y = a * 2; p }
+
+arr(a: i32) -> [i32; 3] { var r: [i32; 3]; r[0] = a; r[1] = a + 1; r[2] = a + 2; r }
+
+pair(a: i32) -> (i32, i32) { (a, a + 1) }
+
+bump(r: &i32) { r = r + 10 }
+
+total(s: [i32]) -> i32 {
+    var t = 0
+    for i in 0 .. s.len { t = t + s[i] }
+    t
+}
+
+apply(f: i32 -> P, a: i32) -> P { f(a) }
+
+main {
+    // Struct returned through a function pointer.
+    var g = mk
+    var p = g(3)
+    assert(p.x == 3)
+    assert(p.y == 6)
+
+    // Struct returned through a function-typed parameter.
+    var q = apply(mk, 5)
+    assert(q.y == 10)
+
+    // Array and tuple returns.
+    var f = arr
+    var xs = f(1)
+    assert(xs[2] == 3)
+
+    var h = pair
+    var t = h(7)
+    assert(t.0 == 7)
+    assert(t.1 == 8)
+
+    // Reference parameter through a function pointer.
+    var b = bump
+    var v = 5
+    b(v)
+    assert(v == 15)
+
+    // Sized array coerced to a slice parameter through a function pointer.
+    var sum = total
+    var a = [1, 2, 3]
+    assert(sum(a) == 6)
+
+    // Struct returned through a lambda.
+    var lam = (|n| mk(n))
+    assert(lam(4).y == 8)
+}

--- a/tests/cases/references/ref_alias_closure.lyte
+++ b/tests/cases/references/ref_alias_closure.lyte
@@ -1,0 +1,17 @@
+// The no-alias rule applies to calls through a fat pointer too, not just to
+// direct named calls.
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/references/ref_alias_closure.lyte:16:5: cannot pass 'x' to multiple borrowed parameters (borrowed arguments must not alias)
+//         f(x, x)
+//         ^
+
+fn swap(a: &i32, b: &i32) {
+    a = b
+}
+
+main {
+    var x = 1
+    var f = swap
+    f(x, x)
+}

--- a/tests/cases/references/ref_literal_arg_closure.lyte
+++ b/tests/cases/references/ref_literal_arg_closure.lyte
@@ -1,0 +1,16 @@
+// Reference arguments must be assignable when the callee is reached through a
+// fat pointer, not just when it is named directly.
+// args: --check
+// expected stdout:
+// ❌ ../tests/cases/references/ref_literal_arg_closure.lyte:15:7: reference argument must be assignable
+//         g(1)
+//           ^
+
+fn set(x: &i32) {
+    x = 2
+}
+
+main {
+    var g = set
+    g(1)
+}

--- a/tests/cases/simd/f32x4_closure_return.lyte
+++ b/tests/cases/simd/f32x4_closure_return.lyte
@@ -1,0 +1,22 @@
+// f32x4 returned from a call through a fat pointer. The VM backend returns
+// f32x4 via an sret output pointer like every other pointer-represented type,
+// so the result must not alias the callee's frame.
+// expected stdout:
+// compilation successful
+// 2
+// 8
+// 20
+
+dbl(v: f32x4) -> f32x4 { v + v }
+
+apply(f: f32x4 -> f32x4, v: f32x4) -> f32x4 { f(v) }
+
+main {
+    var f = dbl
+    var r = f(f32x4(1.0, 2.0, 3.0, 4.0))
+    print(r[0] as i32)
+    print(r[3] as i32)
+
+    var s = apply(dbl, f32x4(10.0, 20.0, 30.0, 40.0))
+    print(s[0] as i32)
+}


### PR DESCRIPTION
Fixes #44.

## Problem

The direct-call paths in `src/stack_codegen.rs` and `src/vm_codegen.rs` allocate an output slot for pointer-returned types, pass its address as an extra first argument, and push that address as the call's result. They also coerce `&T` params to addresses (`translate_lvalue`) and wrap sized arrays as slices.

The `CallClosure` paths did none of that. A closure or function pointer returning a struct passed one argument too few and consumed a result that was never produced:

```
struct P { x: i32, y: i32 }
mk(a: i32) -> P { var p: P; p.x = a; p.y = a * 2; p }
main { var g = mk; var p = g(3); assert(p.x == 3) }
```

| backend | before | after |
| --- | --- | --- |
| `jit` | ok | ok |
| `asm` | segfault (139) | ok |
| `stack` | segfault (139) | ok |
| `vm` | panic `src/vm.rs:1290`, "attempt to subtract with overflow" | ok |

## Fix

Fold both `CallClosure` sites in each backend into a single `translate_closure_call` that mirrors the direct-call ABI:

- sret output pointer as the extra first argument when `returns_via_pointer(ret_ty)`, with the arg count bumped and the output storage's address used as the call's result (sret callees return void, so the float/void bridging only applies on the non-sret path);
- `Reference` params passed by address;
- sized arrays wrapped as slices where the callee expects one.

Callee param types come from the solved `Type::Func` domain of the function expression.

### Also: f32x4 returns in the VM backend

`vm_codegen`'s `returns_via_pointer` was missing `Type::Float32x4`, so f32x4 returns used a "return the address of the callee's frame slot in r0, caller memcpys after the frame pops" convention. Direct calls survived that by luck; closure calls read zeros on both `vm` and `asm`. Adding `Float32x4` puts it on sret like every other pointer-represented type, matching what the stack backend already did.

## Tests

New golden tests, run against all four backends:

- `tests/cases/lambdas/closure_abi.lyte` — struct, array, and tuple returns through a function pointer, a function-typed parameter, and a lambda; `&i32` param; sized array coerced to a slice param.
- `tests/cases/simd/f32x4_closure_return.lyte` — f32x4 returned through a function pointer and a function-typed parameter.

`cargo test --workspace` passes: 380 lib tests plus `golden_tests_jit` / `golden_tests_vm` / `golden_tests_asm` / `golden_tests_stack`. `cargo fmt --check` diff count is unchanged (all pre-existing, in files this PR doesn't touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeNzkFkzMbdH3XPzitDmVa