### PR TITLE
Tag last when cutting a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,31 @@
 name: Release xcframework
 
+# Cut a release by running this workflow (Actions -> Release xcframework -> Run
+# workflow) with the version number, e.g. "0.36". Do NOT create the GitHub
+# release or the tag by hand.
+#
+# The tag is created LAST, on purpose. Package.swift's binaryTarget must name
+# the URL and checksum of the artifact for the release being cut, so the commit
+# that updates Package.swift has to exist before the tag does. The old
+# release-triggered flow tagged first and pushed the Package.swift update
+# afterwards, which left every tag pointing at the *previous* release's
+# xcframework (see issue #37: tag 0.35 downloaded the 0.34 artifact, whose
+# header predated lyte_program_has_entry_point, so the package failed to build
+# for anyone resolving by version instead of by branch).
+#
+# Order: build -> update Package.swift on main -> create release + tag at that
+# commit -> verify a clean checkout of the tag actually builds.
+
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 0.36 (must not already exist)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
 
 jobs:
   xcframework:
@@ -10,6 +33,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: main
+        fetch-depth: 0
+
+    - name: Validate version
+      env:
+        TAG: ${{ inputs.version }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        case "$TAG" in
+          ''|*[!0-9.]*)
+            echo "Error: version must be digits and dots, got '$TAG'" >&2
+            exit 1
+            ;;
+        esac
+        git fetch --tags --quiet
+        if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+          echo "Error: tag $TAG already exists" >&2
+          exit 1
+        fi
+        if gh release view "$TAG" >/dev/null 2>&1; then
+          echo "Error: release $TAG already exists" >&2
+          exit 1
+        fi
 
     - name: Install arm64 LLVM 18 and libffi
       run: brew install llvm@18 libffi
@@ -30,30 +77,99 @@ jobs:
     - name: Build xcframework
       run: ./build-xcframework.sh
 
-    - name: Upload xcframework to release
+    - name: Update Package.swift for the pending release
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload "${{ github.event.release.tag_name }}" CLyte.xcframework.zip --clobber
-
-    - name: Update Package.swift with new URL and checksum
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ inputs.version }}
+        REPO: ${{ github.repository }}
       run: |
-        TAG="${{ github.event.release.tag_name }}"
         CHECKSUM=$(swift package compute-checksum CLyte.xcframework.zip)
-        URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/CLyte.xcframework.zip"
+        URL="https://github.com/${REPO}/releases/download/${TAG}/CLyte.xcframework.zip"
 
-        # Update URL and checksum in Package.swift
         sed -i '' "s|url: \"https://github.com/.*/CLyte.xcframework.zip\"|url: \"${URL}\"|" Package.swift
         sed -i '' "s|checksum: \"[a-f0-9]*\"|checksum: \"${CHECKSUM}\"|" Package.swift
+
+        # The sed patterns are load-bearing: if either stops matching, the tag
+        # would ship a Package.swift pointing at the wrong artifact.
+        grep -q "url: \"${URL}\"" Package.swift || {
+          echo "Error: failed to rewrite binaryTarget url in Package.swift" >&2
+          exit 1
+        }
+        grep -q "checksum: \"${CHECKSUM}\"" Package.swift || {
+          echo "Error: failed to rewrite binaryTarget checksum in Package.swift" >&2
+          exit 1
+        }
 
         echo "Updated Package.swift:"
         grep -A1 'url:' Package.swift
 
-    - name: Commit and push Package.swift
+    - name: Commit Package.swift to main
+      id: commit
+      env:
+        TAG: ${{ inputs.version }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add Package.swift
-        git commit -m "Update Package.swift for release ${{ github.event.release.tag_name }}"
-        git push origin HEAD:main
+
+        if git diff --quiet -- Package.swift; then
+          echo "Package.swift already up to date; tagging current main."
+        else
+          git add Package.swift
+          git commit -m "Update Package.swift for release ${TAG}"
+
+          # main may have moved while the xcframework was building.
+          pushed=0
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              pushed=1
+              break
+            fi
+            echo "Push rejected (attempt ${attempt}); rebasing on main and retrying."
+            git pull --rebase origin main
+          done
+          if [ "$pushed" != 1 ]; then
+            echo "Error: could not push Package.swift to main" >&2
+            exit 1
+          fi
+        fi
+
+        echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Create release and tag at that commit
+      env:
+        TAG: ${{ inputs.version }}
+        SHA: ${{ steps.commit.outputs.sha }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create "$TAG" \
+          --target "$SHA" \
+          --title "$TAG" \
+          --generate-notes \
+          CLyte.xcframework.zip
+
+    - name: Verify a clean checkout of the tag builds
+      env:
+        TAG: ${{ inputs.version }}
+        REPO: ${{ github.repository }}
+      run: |
+        # Catches the issue #37 class of failure: the Swift wrapper calling an
+        # FFI symbol the tagged artifact's header doesn't export.
+        rm -rf "$RUNNER_TEMP/verify"
+
+        # The tag was created seconds ago; allow for replication lag.
+        cloned=0
+        for attempt in 1 2 3; do
+          if git clone --depth 1 --branch "$TAG" \
+              "https://github.com/${REPO}.git" "$RUNNER_TEMP/verify"; then
+            cloned=1
+            break
+          fi
+          echo "Clone of tag $TAG failed (attempt ${attempt}); retrying."
+          rm -rf "$RUNNER_TEMP/verify"
+          sleep 10
+        done
+        if [ "$cloned" != 1 ]; then
+          echo "Error: could not clone tag $TAG" >&2
+          exit 1
+        fi
+
+        swift build --package-path "$RUNNER_TEMP/verify"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,16 @@ name: Release xcframework
 # header predated lyte_program_has_entry_point, so the package failed to build
 # for anyone resolving by version instead of by branch).
 #
-# Order: build -> update Package.swift on main -> create release + tag at that
-# commit -> verify a clean checkout of the tag actually builds.
+# Order matters in both directions. Nothing reaches main until the release is
+# published and verified, because a Package.swift on main naming an artifact
+# that does not exist yet breaks every consumer resolving by branch. So the
+# Package.swift commit is staged on a throwaway release/<tag> branch, the
+# release and tag are created there, and main is fast-forwarded onto it only
+# once the published tag has been verified.
+#
+#   build -> verify against the local xcframework -> stage the Package.swift
+#   commit -> create release + tag there -> verify the published tag ->
+#   fast-forward main
 
 on:
   workflow_dispatch:
@@ -31,6 +39,11 @@ jobs:
   xcframework:
     runs-on: macos-latest
 
+    env:
+      TAG: ${{ inputs.version }}
+      REPO: ${{ github.repository }}
+      STAGING: release/${{ inputs.version }}
+
     steps:
     - uses: actions/checkout@v5
       with:
@@ -38,16 +51,17 @@ jobs:
         fetch-depth: 0
 
     - name: Validate version
+      id: setup
       env:
-        TAG: ${{ inputs.version }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        case "$TAG" in
-          ''|*[!0-9.]*)
-            echo "Error: version must be digits and dots, got '$TAG'" >&2
-            exit 1
-            ;;
-        esac
+        # Strict shape: a typo'd "036" would otherwise produce a real tag and a
+        # Package.swift URL that nothing can ever resolve.
+        printf '%s' "$TAG" | grep -Eq '^[0-9]+\.[0-9]+(\.[0-9]+)?$' || {
+          echo "Error: version must look like 0.36 or 0.36.1, got '$TAG'" >&2
+          exit 1
+        }
+
         git fetch --tags --quiet
         if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
           echo "Error: tag $TAG already exists" >&2
@@ -57,6 +71,15 @@ jobs:
           echo "Error: release $TAG already exists" >&2
           exit 1
         fi
+        if git ls-remote --exit-code --heads origin "$STAGING" >/dev/null 2>&1; then
+          echo "Error: staging branch $STAGING already exists (leftover from a failed run?)" >&2
+          exit 1
+        fi
+
+        # The artifact is built from this commit, and this is the commit that
+        # gets tagged. Recording it keeps the tagged tree and the shipped
+        # binary in lockstep.
+        echo "build_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
     - name: Install arm64 LLVM 18 and libffi
       run: brew install llvm@18 libffi
@@ -77,10 +100,29 @@ jobs:
     - name: Build xcframework
       run: ./build-xcframework.sh
 
+    - name: Verify the package builds against the new xcframework
+      run: |
+        # The issue #37 check, run before anything is published: does the Swift
+        # wrapper at this commit compile against the header in the xcframework
+        # we just built? Uses a local binaryTarget path, so no release needed.
+        rm -rf "$RUNNER_TEMP/preflight"
+        mkdir -p "$RUNNER_TEMP/preflight"
+        git archive HEAD | tar -x -C "$RUNNER_TEMP/preflight"
+        cp -R CLyte.xcframework "$RUNNER_TEMP/preflight/"
+
+        cd "$RUNNER_TEMP/preflight"
+        sed -i '' \
+          -e '/url: "https:\/\/github.com\/.*\/CLyte.xcframework.zip",/d' \
+          -e 's|checksum: "[a-f0-9]*"|path: "CLyte.xcframework"|' \
+          Package.swift
+        grep -q 'path: "CLyte.xcframework"' Package.swift || {
+          echo "Error: failed to point binaryTarget at the local xcframework" >&2
+          exit 1
+        }
+
+        swift build
+
     - name: Update Package.swift for the pending release
-      env:
-        TAG: ${{ inputs.version }}
-        REPO: ${{ github.repository }}
       run: |
         CHECKSUM=$(swift package compute-checksum CLyte.xcframework.zip)
         URL="https://github.com/${REPO}/releases/download/${TAG}/CLyte.xcframework.zip"
@@ -102,42 +144,44 @@ jobs:
         echo "Updated Package.swift:"
         grep -A1 'url:' Package.swift
 
-    - name: Commit Package.swift to main
-      id: commit
+    - name: Stage the Package.swift commit
+      id: stage
       env:
-        TAG: ${{ inputs.version }}
+        BUILD_SHA: ${{ steps.setup.outputs.build_sha }}
       run: |
+        # Refuse to tag a tree the artifact was not built from. If main moved
+        # during the build, a rebase would tag sources newer than the binary —
+        # exactly the issue #37 shape (a new FFI symbol in Lyte.swift that the
+        # shipped header lacks).
+        git fetch origin main
+        REMOTE_MAIN=$(git rev-parse origin/main)
+        if [ "$REMOTE_MAIN" != "$BUILD_SHA" ]; then
+          echo "Error: main moved during the build ($BUILD_SHA -> $REMOTE_MAIN)." >&2
+          echo "Nothing was published. Re-run the release to build from current main." >&2
+          exit 1
+        fi
+
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
         if git diff --quiet -- Package.swift; then
-          echo "Package.swift already up to date; tagging current main."
+          echo "Package.swift already up to date; tagging $BUILD_SHA as is."
         else
           git add Package.swift
           git commit -m "Update Package.swift for release ${TAG}"
-
-          # main may have moved while the xcframework was building.
-          pushed=0
-          for attempt in 1 2 3; do
-            if git push origin HEAD:main; then
-              pushed=1
-              break
-            fi
-            echo "Push rejected (attempt ${attempt}); rebasing on main and retrying."
-            git pull --rebase origin main
-          done
-          if [ "$pushed" != 1 ]; then
-            echo "Error: could not push Package.swift to main" >&2
-            exit 1
-          fi
         fi
 
+        # Staged on a throwaway branch, not main: the commit names an artifact
+        # that does not exist yet, so it must not reach consumers until the
+        # release is published and verified.
+        git push origin "HEAD:refs/heads/${STAGING}"
+        echo "pushed=true" >> "$GITHUB_OUTPUT"
         echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-    - name: Create release and tag at that commit
+    - name: Create release and tag at the staged commit
+      id: release
       env:
-        TAG: ${{ inputs.version }}
-        SHA: ${{ steps.commit.outputs.sha }}
+        SHA: ${{ steps.stage.outputs.sha }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release create "$TAG" \
@@ -145,14 +189,13 @@ jobs:
           --title "$TAG" \
           --generate-notes \
           CLyte.xcframework.zip
+        echo "created=true" >> "$GITHUB_OUTPUT"
 
-    - name: Verify a clean checkout of the tag builds
-      env:
-        TAG: ${{ inputs.version }}
-        REPO: ${{ github.repository }}
+    - name: Verify the published tag builds
+      id: verify
       run: |
-        # Catches the issue #37 class of failure: the Swift wrapper calling an
-        # FFI symbol the tagged artifact's header doesn't export.
+        # Belt and braces over the pre-publish check: this resolves the real
+        # release URL and checksum the way a version-pinned consumer does.
         rm -rf "$RUNNER_TEMP/verify"
 
         # The tag was created seconds ago; allow for replication lag.
@@ -173,3 +216,41 @@ jobs:
         fi
 
         swift build --package-path "$RUNNER_TEMP/verify"
+
+    - name: Fast-forward main onto the released commit
+      env:
+        SHA: ${{ steps.stage.outputs.sha }}
+      run: |
+        # Only now, with the artifact published and verified, is it safe for
+        # branch consumers to see this Package.swift.
+        for attempt in 1 2 3; do
+          if git push origin "${SHA}:main"; then
+            exit 0
+          fi
+          echo "Push rejected (attempt ${attempt}); main moved. Replaying onto it."
+          git fetch origin main
+          git rebase origin/main || {
+            echo "Error: could not replay Package.swift onto main." >&2
+            echo "Release $TAG is published and verified; push the commit manually." >&2
+            exit 1
+          }
+          SHA=$(git rev-parse HEAD)
+        done
+        echo "Error: could not push Package.swift to main" >&2
+        echo "Release $TAG is published and verified; push $SHA to main manually." >&2
+        exit 1
+
+    - name: Roll back the release if it could not be published or verified
+      # Scoped to the publish/verify failures. A failure to fast-forward main
+      # leaves a good release behind and must not delete it.
+      if: failure() && (steps.release.outcome == 'failure' || steps.verify.outcome == 'failure')
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "Deleting release and tag $TAG so the version can be re-run."
+        gh release delete "$TAG" --yes --cleanup-tag || true
+        git push origin --delete "refs/tags/$TAG" 2>/dev/null || true
+
+    - name: Delete the staging branch
+      if: always() && steps.stage.outputs.pushed == 'true'
+      run: git push origin --delete "$STAGING" || true

--- a/README.md
+++ b/README.md
@@ -415,17 +415,30 @@ Entry point handles are resolved once at compile time and called with zero overh
 
 ## Releasing
 
-Creating a release builds and publishes the xcframework automatically:
+Run the **Release xcframework** workflow from the Actions tab (or with `gh`),
+passing the version number:
 
 ```bash
-gh release create v0.12
+gh workflow run release.yml -f version=0.36
 ```
 
-This triggers the `release.yml` CI workflow which:
+Do **not** create the release or the tag by hand — the workflow creates both,
+and creating them yourself produces a release with no xcframework attached.
 
-1. Builds `CLyte.xcframework` for macOS (ARM64 + x86_64) and iOS
-2. Uploads `CLyte.xcframework.zip` as a release asset
-3. Computes the checksum and updates `Package.swift` on main
+The `release.yml` CI workflow:
+
+1. Fails fast if the version is malformed or the tag/release already exists
+2. Builds `CLyte.xcframework` for macOS (ARM64 + x86_64) and iOS
+3. Computes the checksum and commits the new URL + checksum to `Package.swift` on main
+4. Creates the release and tag **at that commit**, uploading `CLyte.xcframework.zip`
+5. Clones the fresh tag and runs `swift build` against it to verify
+
+Step 4 is the reason the tag comes last. `Package.swift`'s `binaryTarget` has to
+name the URL and checksum of the artifact for the release being cut, so the
+commit updating it must exist before the tag does. Tagging first leaves the tag
+pointing at the previous release's xcframework, which breaks consumers who pin a
+version as soon as the Swift wrapper starts calling a newly added FFI symbol
+(see issue #37).
 
 The xcframework is self-contained — LLVM dependencies (zstd, ffi) are statically linked into the ARM64 macOS library. Swift consumers only need system libraries (libc++, libz, libcurses).
 

--- a/README.md
+++ b/README.md
@@ -429,16 +429,26 @@ The `release.yml` CI workflow:
 
 1. Fails fast if the version is malformed or the tag/release already exists
 2. Builds `CLyte.xcframework` for macOS (ARM64 + x86_64) and iOS
-3. Computes the checksum and commits the new URL + checksum to `Package.swift` on main
-4. Creates the release and tag **at that commit**, uploading `CLyte.xcframework.zip`
-5. Clones the fresh tag and runs `swift build` against it to verify
+3. Builds the Swift package against that xcframework, before publishing anything
+4. Commits the new URL + checksum to `Package.swift` on a `release/<version>` branch
+5. Creates the release and tag **at that commit**, uploading `CLyte.xcframework.zip`
+6. Clones the fresh tag and runs `swift build` against it
+7. Fast-forwards `main` onto the released commit, and deletes the staging branch
 
-Step 4 is the reason the tag comes last. `Package.swift`'s `binaryTarget` has to
-name the URL and checksum of the artifact for the release being cut, so the
-commit updating it must exist before the tag does. Tagging first leaves the tag
-pointing at the previous release's xcframework, which breaks consumers who pin a
-version as soon as the Swift wrapper starts calling a newly added FFI symbol
-(see issue #37).
+The tag comes last because `Package.swift`'s `binaryTarget` has to name the URL
+and checksum of the artifact for the release being cut, so the commit updating
+it must exist before the tag does. Tagging first leaves the tag pointing at the
+previous release's xcframework, which breaks consumers who pin a version as soon
+as the Swift wrapper starts calling a newly added FFI symbol (see issue #37).
+
+`main` comes last for the mirror-image reason: a `Package.swift` on `main` naming
+an artifact that does not exist yet breaks everyone resolving by branch. Hence
+the staging branch — nothing reaches `main` until the release is published and
+verified. If a release fails or the version is wrong, the release and tag are
+deleted so the version can be re-run, and `main` was never touched.
+
+If `main` moves while the xcframework is building, the workflow aborts before
+publishing rather than tagging sources the binary was not built from. Re-run it.
 
 The xcframework is self-contained — LLVM dependencies (zstd, ffi) are statically linked into the ARM64 macOS library. Swift consumers only need system libraries (libc++, libz, libcurses).
 


### PR DESCRIPTION
Fixes #37.

## The bug

The release workflow triggered on `release: created`, so the tag already existed when the job started. It built the xcframework, uploaded it to that release, then pushed the `Package.swift` URL/checksum update to `main` *afterwards*. The tag never moved, so every tagged commit references the **previous** release's artifact:

```
0.32 -> download/0.31/
0.33 -> download/0.32/
0.34 -> download/0.33/
0.35 -> download/0.34/
```

`b4b8b2f "Update Package.swift for release 0.35"` is not an ancestor of tag `0.35` — it is the commit right after it, on `main` only.

This stayed harmless for many releases because the N-1 binary happened to export everything the Swift wrapper called. 0.35 broke it: #35 added `lyte_program_has_entry_point` to both `Sources/CLyte/include/lyte.h` and `Sources/Lyte/Lyte.swift:127` in the same release. `CLyte` is a pure `binaryTarget`, so the header the Swift target compiles against comes from the *downloaded* xcframework, not from `Sources/CLyte/include`. Tag 0.35 downloads the 0.34 xcframework, whose header predates the symbol.

Consumers resolving by branch (as Audulus does) never saw this, because `main` always has the corrected `Package.swift`. The reporter is the first to pin by version.

## The fix

Cut releases via `workflow_dispatch` with a version input instead of by creating a release in the UI, and create the tag **last**:

build -> update `Package.swift` on `main` -> `gh release create "$TAG" --target <that commit sha>` -> verify

`gh release create --target` creates the tag, the release, and uploads the asset at the commit that already names the right URL and checksum.

## Guards

- Version must be digits/dots, and the tag and release must not already exist — fails in seconds rather than after a ~30 minute LLVM build.
- Both `sed` rewrites are verified with `grep -q`. A silently non-matching pattern would otherwise tag a `Package.swift` pointing at the wrong artifact.
- The push retries with `pull --rebase` (3x), since `main` can move during the build. The commit is skipped entirely if `Package.swift` is already correct.
- The final step clones the fresh tag into a clean directory and runs `swift build`. That is exactly the consumer's build path, so an issue #37 class mismatch now fails the release job instead of reaching users.

## Note

This only fixes future releases. Tag 0.35 stays broken for version-pinned consumers; cutting 0.36 from `main` (the first run of this workflow) unblocks them, and its verify step would prove the tag is good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeNzkFkzMbdH3XPzitDmVa