### PR TITLE
Close out the array-capture miscompile (#42)

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1287,7 +1287,7 @@ impl VM {
                      locals: {locals_start:#x}..{locals_end:#x}\n  \
                      globals: {globals_start:#x}..{globals_end:#x}\n  \
                      heap: {heap_start:#x}..{heap_end:#x}",
-                    ptr, self.ip - 1,
+                    ptr, self.ip.saturating_sub(1),
                 );
             }
         }

--- a/tests/cases/lambdas/capture_array_var.lyte
+++ b/tests/cases/lambdas/capture_array_var.lyte
@@ -1,0 +1,28 @@
+// A lambda capturing an array local declared with `var` reads the array
+// itself, not the first word of its storage. The closure slot holds the
+// address of the array, so it must not be dereferenced again.
+//
+// expected stdout:
+// compilation successful
+// 12
+// 18
+// 12
+
+main {
+    var arr: [i32; 4]
+    arr[0] = 1
+    arr[1] = 2
+    arr[2] = 11
+    arr[3] = 4
+
+    // Stored in a variable, then called.
+    var g = (|x| arr[2] + x)
+    print(g(1))
+
+    // Capturing every element.
+    var sum = (|| arr[0] + arr[1] + arr[2] + arr[3])
+    print(sum())
+
+    // Immediately invoked.
+    print((|x| arr[2] + x)(1))
+}

--- a/tests/cases/lambdas/lambda_guarded_ok.lyte
+++ b/tests/cases/lambdas/lambda_guarded_ok.lyte
@@ -1,9 +1,11 @@
 // A lambda that guards its own parameter is provably safe, so the checker
-// accepts it. Only checked, not run: a lambda that captures an array still
-// misbehaves on the vm/asm/stack backends (unrelated to the safety checker).
+// accepts it, and the guards hold at run time on every backend.
 //
-// args: --check
 // expected stdout:
+// compilation successful
+// -1
+// 0
+// 11
 
 main {
     var arr: [i32; 4]


### PR DESCRIPTION
The miscompile in #42 was fixed by 786199c: the VM and stack backends loaded through the closure slot for aggregate captures, but for an array, struct or slice the captured pointer already *is* the value's representation. The issue's repro now prints `12` on `jit`, `vm`, `asm`, and `stack`.

This PR picks up the two loose ends the issue listed alongside it.

**Don't underflow `ip` in the VM's out-of-bounds panic.** `self.ip - 1` panics with `attempt to subtract with overflow` when the fault happens at ip 0, so the message that matters — the bad address, its size, and the locals/globals/heap ranges — is never printed. `saturating_sub(1)` keeps the diagnostic.

**Promote `lambda_guarded_ok.lyte` to a run test.** It was `--check`-only solely because an array capture misbehaved at run time; it now runs on every backend and expects `-1`, `0`, `11`.

**Add `capture_array_var.lyte`** for the shape `capture_array_local.lyte` doesn't cover: a `var`-declared array local captured by a stored lambda, by a no-arg lambda reading every element, and by an immediately-invoked lambda.

## Testing

`cargo test --workspace` is green — golden tests pass on all four backends (jit, vm, asm, stack).

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeNzkFkzMbdH3XPzitDmVa