### PR TITLE
Don't hoist field reads through loop-local bindings

### DIFF
--- a/src/hoist.rs
+++ b/src/hoist.rs
@@ -166,8 +166,9 @@ fn collect_written_fields(expr_id: ExprID, fdecl: &FuncDecl, written: &mut HashS
             collect_written_fields(*body, fdecl, written);
         }
         Expr::For {
-            start, end, body, ..
+            var, start, end, body,
         } => {
+            written.insert((*var, Name::str("*")));
             collect_written_fields(*start, fdecl, written);
             collect_written_fields(*end, fdecl, written);
             collect_written_fields(*body, fdecl, written);
@@ -202,15 +203,25 @@ fn collect_written_fields(expr_id: ExprID, fdecl: &FuncDecl, written: &mut HashS
         Expr::Return(e) | Expr::Assume(e) => {
             collect_written_fields(*e, fdecl, written);
         }
-        Expr::Var(_, init, _) => {
+        Expr::Var(name, init, _) => {
+            // A binding introduced inside the loop is a fresh variable on every
+            // iteration, and it doesn't exist before the loop at all — nothing
+            // about it can be hoisted.
+            written.insert((*name, Name::str("*")));
             if let Some(e) = init {
                 collect_written_fields(*e, fdecl, written);
             }
         }
-        Expr::Let(_, init, _) => {
+        Expr::Let(name, init, _) => {
+            written.insert((*name, Name::str("*")));
             collect_written_fields(*init, fdecl, written);
         }
-        Expr::Lambda { body, .. } => {
+        Expr::Lambda { params, body } => {
+            // Lambda parameters shadow anything of the same name in the
+            // enclosing scope, so reads through them aren't invariant either.
+            for p in params {
+                written.insert((p.name, Name::str("*")));
+            }
             collect_written_fields(*body, fdecl, written);
         }
         Expr::AsTy(e, _) => {

--- a/tests/cases/loops/loop_local_struct_binding.lyte
+++ b/tests/cases/loops/loop_local_struct_binding.lyte
@@ -1,0 +1,46 @@
+// Regression test for #49: a struct-returning call bound to a `var`/`let`
+// inside a loop body is re-evaluated every iteration, so the loop-invariant
+// field hoister must not lift `q.x` out of the loop — the binding doesn't
+// even exist before the loop.
+// expected stdout:
+// compilation successful
+// 0
+// 1
+// 2
+// 10
+// 11
+// 12
+// assert(true)
+
+struct P {
+    x: i32
+}
+
+mk(k: i32) → P {
+    var p: P
+    p.x = k
+    return p
+}
+
+main {
+    var k = 0
+    while k < 3 {
+        var q = mk(k)
+        print(q.x)
+        k = k + 1
+    }
+
+    for i in 0 .. 3 {
+        let r = mk(i + 10)
+        print(r.x)
+    }
+
+    var sum = 0
+    var j = 0
+    while j < 3 {
+        let s = mk(j)
+        sum = sum + s.x
+        j = j + 1
+    }
+    assert(sum == 3)
+}


### PR DESCRIPTION
Fixes #49.

## Root cause

Not the backends — the loop-invariant field hoister in `src/hoist.rs`.

`collect_written_fields` walked into `Expr::Var`/`Expr::Let` *initializers* but never recorded the **bound name** as clobbered. So in

```lyte
while k < 3 {
    var q = mk(k)
    print(q.x)
    k = k + 1
}
```

`q` looked loop-invariant, and the pass rewrote the body to reference a hoisted `let __hoisted_q_x = q.x` inserted **before** the loop — pointing at a variable that doesn't exist yet.

Each backend then fell over in its own way. The JIT looked `q` up in its variable map, missed, and fell through to `translate_func`, hence the odd-looking `JIT wrap_as_func_pair: expected function type, got Name("P", [])`. The VM, asm, and stack backends read garbage.

The struct return in the issue's repro is incidental: it's what makes the binding's use a *field read*, which is the only thing the hoister looks at. A variant where the binding is never read compiles fine, which is what pinned it to the hoister.

## Fix

Mark any name **bound** inside the loop as wholly written (`(name, "*")`):

- `Expr::Var(name, ..)` and `Expr::Let(name, ..)` — a binding introduced in the body is a fresh variable each iteration and doesn't exist before the loop at all.
- `Expr::Lambda` params — same shadowing hazard, latent.
- `Expr::For`'s induction variable — likewise.

I instrumented the pass temporarily to confirm both directions: it still fires for its intended case (a struct declared *outside* the loop still yields `__hoisted_c_gain`), and no longer fires on loop-local bindings.

## Test

`tests/cases/loops/loop_local_struct_binding.lyte`. The golden runner already sweeps every backend, so one file covers jit/vm/asm/stack. All four now print `0 1 2 / 10 11 12` and pass the accumulate assert.

Full suite: 380 + 4 + 21 passing, 0 failures.

## Unrelated bug found while writing the test

Filed as #56 — a `let` inside a `while` body shadowing an outer struct `var` reads the outer variable on the `vm` and `asm` backends. I confirmed the hoister doesn't fire on that program, so it's an independent pre-existing defect; I renamed the shadowed bindings in this PR's golden test to keep it scoped to #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeNzkFkzMbdH3XPzitDmVa
