### PR TITLE
Recover the hoist regression test stranded by PR #55

### DIFF
--- a/tests/cases/structs/struct_var_in_loop.lyte
+++ b/tests/cases/structs/struct_var_in_loop.lyte
@@ -1,0 +1,88 @@
+// A struct-returning call bound to a var inside a loop body used to be
+// mis-hoisted: the field read `q.x` was lifted into a `let` placed before the
+// loop, where `q` does not exist yet. See issue #49. This file recovers the
+// wider coverage from PR #55, which was merged into a branch that had already
+// been squashed into main and so never landed.
+// expected stdout:
+// compilation successful
+// 0
+// 1
+// 2
+// 10
+// 11
+// 12
+// 7
+// 7
+// 7
+// 2
+// 11
+
+struct P {
+    x: i32
+}
+
+mk(k: i32) → P {
+    var p: P
+    p.x = k
+    return p
+}
+
+// Two struct types sharing a field name at different offsets, so a hoisted
+// read typed against the wrong one reads the wrong field.
+struct A {
+    a: i32,
+    x: i32
+}
+
+struct B {
+    x: i32,
+    b: i32
+}
+
+mk_a() → A {
+    var r: A
+    r.a = 1
+    r.x = 2
+    return r
+}
+
+mk_b() → B {
+    var r: B
+    r.x = 11
+    r.b = 22
+    return r
+}
+
+main {
+    var k = 0
+    while k < 3 {
+        var q = mk(k)
+        print(q.x)
+        k = k + 1
+    }
+
+    // Same shape with a for loop, and with the loop-local name shadowing an
+    // outer binding of the same type.
+    var q = mk(7)
+    for i in 0 .. 3 {
+        var q = mk(i + 10)
+        print(q.x)
+    }
+
+    // The outer q is untouched, and its field is still a genuine
+    // loop-invariant read.
+    for i in 0 .. 3 {
+        print(q.x)
+    }
+
+    // The loop-local `v: A` must not lend its type to the hoisted read of the
+    // outer `v: B` below — that would load A's `x` offset out of a B.
+    for i in 0 .. 1 {
+        var v = mk_a()
+        print(v.x)
+    }
+    var v = mk_b()
+    for i in 0 .. 1 {
+        print(v.x)
+    }
+}


### PR DESCRIPTION
PR #55 targeted `fix-50-f32x4-capture-jit` and merged into it at 20:40, but that branch had already been squash-merged into main as #52 at 18:07. The squash captured the branch as it stood before #55 landed, so #55's contents never reached main — its merge commit `0629f70` is not an ancestor of main, and `origin/main..0629f70` still shows four unmerged commits.

The fix itself was re-landed independently by #57, so **no behavior was lost**. The test was.

#57's `tests/cases/loops/loop_local_struct_binding.lyte` covers the basic `while` and `for` cases. It does not cover the two that fail by computing a *wrong value* rather than by refusing to compile:

- a loop-local binding shadowing an outer one of the same name, where the outer read is still genuinely invariant and must keep being hoisted
- two structs sharing a field name at different offsets, where a hoisted read typed against the wrong one loads the wrong field

Both already pass at HEAD — the loop-local guard in `collect_written_fields` (`src/hoist.rs:385`) covers the first, and taking base and field types from the read site rather than by name (`src/hoist.rs:296`) covers the second. This PR only restores the coverage; there is no code change.

## Verification

- Full suite green: 380 lib, 4 golden, 21 lsp, 0 failures.
- Confirmed the file is actually exercised rather than silently skipped: flipping one expected line failed all four golden suites (`jit`, `vm`, `asm`, `stack`), naming the file in each.
- Separately confirmed the optimization still fires rather than being correct-by-disabling — in the IR for an invariant read the load lands before the loop header, and the loop body only reloads the accumulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeNzkFkzMbdH3XPzitDmVa