### PR TITLE
Store f32x4 lanes at the lane, not at lane 0

### DIFF
--- a/src/stack_codegen.rs
+++ b/src/stack_codegen.rs
@@ -1645,6 +1645,16 @@ impl<'a> FunctionTranslator<'a> {
                 self.translate_lvalue(arr_id, func);
                 let arr_ty = self.representation_type(arr_id);
 
+                // f32x4 lane store: the lane address is base + idx * 4.
+                // The lane index is in 0..4: the safety checker proves it.
+                if matches!(&*arr_ty, Type::Float32x4) {
+                    self.translate_expr(idx_id, func);
+                    func.emit(StackOp::I64Const(4));
+                    func.emit(StackOp::IMul);
+                    func.emit(StackOp::IAdd);
+                    return;
+                }
+
                 let (elem_ty, is_slice) = match &*arr_ty {
                     Type::Array(elem_ty, _) => (*elem_ty, false),
                     Type::Slice(elem_ty) => (*elem_ty, true),

--- a/src/vm_codegen.rs
+++ b/src/vm_codegen.rs
@@ -2196,7 +2196,7 @@ impl<'a> FunctionTranslator<'a> {
             Expr::ArrayIndex(arr_id, idx_id) => {
                 let arr_addr = self.translate_lvalue(*arr_id, func);
                 let idx = self.translate_expr(*idx_id, func);
-                let arr_ty = self.expr_type(*arr_id);
+                let arr_ty = self.representation_type(*arr_id);
 
                 // f32x4 lane store: the lane address is base + idx * 4.
                 // The lane index is in 0..4: the safety checker proves it.

--- a/src/vm_codegen.rs
+++ b/src/vm_codegen.rs
@@ -2198,6 +2198,29 @@ impl<'a> FunctionTranslator<'a> {
                 let idx = self.translate_expr(*idx_id, func);
                 let arr_ty = self.expr_type(*arr_id);
 
+                // f32x4 lane store: the lane address is base + idx * 4.
+                // The lane index is in 0..4: the safety checker proves it.
+                if matches!(&*arr_ty, Type::Float32x4) {
+                    let size_reg = self.alloc_reg();
+                    func.emit(Opcode::LoadImm {
+                        dst: size_reg,
+                        value: 4,
+                    });
+                    let offset = self.alloc_reg();
+                    func.emit(Opcode::IMul {
+                        dst: offset,
+                        a: idx,
+                        b: size_reg,
+                    });
+                    let dst = self.alloc_reg();
+                    func.emit(Opcode::IAdd {
+                        dst,
+                        a: arr_addr,
+                        b: offset,
+                    });
+                    return dst;
+                }
+
                 let (elem_ty, is_slice) = match &*arr_ty {
                     Type::Array(elem_ty, _) => (*elem_ty, false),
                     Type::Slice(elem_ty) => (*elem_ty, true),

--- a/tests/cases/simd/f32x4_lane_store.lyte
+++ b/tests/cases/simd/f32x4_lane_store.lyte
@@ -61,15 +61,15 @@ main {
     // An f32x4 reached through a struct field...
     var q = V(v: f32x4(1.0, 2.0, 3.0, 4.0))
     q.v[j] = 8.0
-    print(q.v.x as i32)
-    print(q.v.z as i32)
-    print(q.v.w as i32)
+    print(q.v[0] as i32)
+    print(q.v[j] as i32)
+    print(q.v[3] as i32)
 
     // ...and through an array element.
     var vs = [f32x4(1.0, 2.0, 3.0, 4.0), f32x4(5.0, 6.0, 7.0, 8.0)]
     vs[1][j] = 9.0
-    print(vs[1].z as i32)
-    print(vs[0].z as i32)
+    print(vs[1][j] as i32)
+    print(vs[0][j] as i32)
 }
 
 struct V { v: f32x4 }

--- a/tests/cases/simd/f32x4_lane_store.lyte
+++ b/tests/cases/simd/f32x4_lane_store.lyte
@@ -1,0 +1,75 @@
+// A lane store `v[i] = x` has to land in lane `i`. The VM-family backends used
+// to take the address of the whole vector as the lvalue and drop the index
+// entirely, so every lane store wrote lane 0.
+//
+// expected stdout:
+// compilation successful
+// 1
+// 2
+// 3
+// 9
+// 20
+// 1
+// 2
+// 3
+// 4
+// 7
+// 0
+// 1
+// 8
+// 4
+// 9
+// 3
+
+var g: f32x4
+
+main {
+    // Non-constant index.
+    var v = f32x4(1.0, 2.0, 3.0, 4.0)
+    var i = 0
+    i = 3
+    v[i] = 9.0
+    print(v[0] as i32)
+    print(v[1] as i32)
+    print(v[2] as i32)
+    print(v[3] as i32)
+
+    // Constant index.
+    v[1] = 20.0
+    print(v[1] as i32)
+
+    // Every lane, written through a loop variable.
+    var w = f32x4(0.0, 0.0, 0.0, 0.0)
+    var k = 0
+    while k < 4 {
+        w[k] = (k as f32) + 1.0
+        k = k + 1
+    }
+    print(w[0] as i32)
+    print(w[1] as i32)
+    print(w[2] as i32)
+    print(w[3] as i32)
+
+    // A global lives at an address rather than in a register.
+    g = f32x4(0.0, 0.0, 0.0, 0.0)
+    var j = 0
+    j = 2
+    g[j] = 7.0
+    print(g[2] as i32)
+    print(g[3] as i32)
+
+    // An f32x4 reached through a struct field...
+    var q = V(v: f32x4(1.0, 2.0, 3.0, 4.0))
+    q.v[j] = 8.0
+    print(q.v.x as i32)
+    print(q.v.z as i32)
+    print(q.v.w as i32)
+
+    // ...and through an array element.
+    var vs = [f32x4(1.0, 2.0, 3.0, 4.0), f32x4(5.0, 6.0, 7.0, 8.0)]
+    vs[1][j] = 9.0
+    print(vs[1].z as i32)
+    print(vs[0].z as i32)
+}
+
+struct V { v: f32x4 }


### PR DESCRIPTION
Fixes #53.

## Root cause

`translate_lvalue`'s `Expr::ArrayIndex` arm matched the base type against `Array`/`Slice` and fell through `_ =>` to returning the **base** address for anything else. An `f32x4` is pointer-represented in the VM-family backends, so `v[i] = x` computed the index, discarded it, and stored at offset 0 — lane 0, whatever `i` was.

The rvalue path (`translate_array_index`) already had an `f32x4` case; the lvalue path never got one.

## Fix

`src/vm_codegen.rs` and `src/stack_codegen.rs`: compute `base + idx * 4` for a `Float32x4` base in the lvalue path, mirroring the existing rvalue lane-extraction code. `asm` shares `vm_codegen`'s bytecode, so it's covered by the same change.

Both hunks key off `representation_type`, matching the rvalue twin and the store-width choice in `translate_assign`.

## One correction to the issue

The constant-index form was broken too — `v[2] = 9.0` printed `9, 3` on `vm`/`asm`/`stack` before this. It goes through the same lvalue path. Only `v.z = 9.0` (the swizzle field, a separate `Expr::Field` arm) was working.

## Test

`tests/cases/simd/f32x4_lane_store.lyte` covers a non-constant index, a constant index, every lane written through a loop variable, a global, and an `f32x4` reached through a struct field and through an array element. The aggregate cases read back through the variable index (`q.v[j]`, `vs[1][j]`) rather than a constant swizzle, so a miscomputed aggregate lane address can't pass.

Verified it fails on the old code (`9 2 3 4 2 4 0 0 0 0 0 8 3 4 7 3`) and passes on all four locally-available backends now. Full `cargo test --workspace` is green: 380 unit + 4 golden-suite runs (jit/vm/asm/stack) + 21 lsp.

`llvm` isn't built locally (feature-gated, needs LLVM 18) so I couldn't run it, but it was already correct per #52 and this change doesn't touch it.

## Not fixed here: f32x4 by reference ICEs the JIT

Taking a reference to an `f32x4` — or to one of its lanes — crashes the Cranelift backend. Both of these now work correctly on `vm`/`asm`/`stack` and ICE on the default `jit` backend:

```lyte
bump(x: &f32) { x = x + 100.0 }
main { var v = f32x4(1.0, 2.0, 3.0, 4.0); bump(v[2]); print(v[2] as i32) }
// jit: panicked at src/jit.rs:826: JIT lvalue subscript: expected array or slice type, got Float32x4
// vm/asm/stack: 103
```

```lyte
fn setlane(p: &f32x4, i: i32) { if i >= 0 { if i < 4 { p[i] = 42.0 } } }
// jit: panicked at src/jit.rs:445: cranelift IR verification failed (call_indirect arg type)
// vm/asm/stack: correct
```

This predates the PR and is untouched by it — `jit.rs` keeps an `f32x4` in a SIMD register, so `translate_lvalue` has no address to hand back and panics instead. Fixing it means spilling to a stack slot and defining write-back semantics, which is a real design decision rather than a missing match arm, so it belongs in its own issue. `src/llvm_jit.rs:1870` has the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeNzkFkzMbdH3XPzitDmVa